### PR TITLE
Add Python log analysis panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# Analises_LOGS
+# Analise de Logs com rsyslog
+
+Este projeto coleta logs gerados pelo `rsyslog`, armazena em um banco de dados
+SQLite e fornece dois paineis de monitoramento:
+
+- **Painel de terminal** utilizando a biblioteca `rich`.
+- **Painel web** simples utilizando Flask.
+
+Logs considerados maliciosos geram alertas imediatos exibidos no terminal.
+
+## Requisitos
+
+- Python 3.8+
+- Dependências listadas em `requirements.txt`
+
+## Instalacao
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+1. Configure o `rsyslog` para gravar seus eventos em `rsyslog.log` na raiz do
+   projeto. Um exemplo simples de configuracao em `/etc/rsyslog.d/50-default.conf`:
+   
+   ```
+   *.* @@127.0.0.1:514
+   ```
+   
+   Em seguida, direcione para arquivo local usando o utilitario `logger` ou uma
+   configuracao personalizada conforme a necessidade.
+
+2. Inicie o coletor que ira ler continuamente o arquivo de log e popular o banco:
+
+```bash
+python -m log_analyzer.collector
+```
+
+3. Para visualizar no terminal:
+
+```bash
+python -m log_analyzer.tui_panel
+```
+
+4. Para acessar pelo navegador:
+
+```bash
+python -m log_analyzer.web_panel
+```
+
+A aplicacao web ficará disponivel em `http://localhost:5000`.
+
+## Estrutura de diretorios
+
+- `log_analyzer/` - codigo fonte principal
+- `rsyslog.log` - arquivo lido pelo coletor (pode ser alterado no codigo)
+- `logs.db` - banco SQLite criado automaticamente
+
+## Alertas
+
+Linhas que contenham termos como `denied`, `attack` ou `malware` sao
+classificadas como **MALICIOUS** e geram uma mensagem de alerta no terminal.

--- a/example.log
+++ b/example.log
@@ -1,0 +1,5 @@
+Jan  1 00:00:01 host1 systemd[1]: Started Session 1 of user root.
+Jan  1 00:01:02 host1 sshd[222]: Failed password for invalid user admin from 1.2.3.4 port 22 ssh2
+Jan  1 00:01:03 host1 kernel: WARNING something might be wrong
+Jan  1 00:01:04 host1 app: User login success
+Jan  1 00:01:05 host1 app: denied attempt to access restricted area

--- a/log_analyzer/collector.py
+++ b/log_analyzer/collector.py
@@ -1,0 +1,34 @@
+import time
+from pathlib import Path
+from log_analyzer.log_db import LogDB
+from log_analyzer.log_parser import parse_log_line
+
+LOG_FILE = Path('rsyslog.log')
+
+
+def follow(file_path: Path):
+    file_path.touch(exist_ok=True)
+    with file_path.open('r') as f:
+        f.seek(0, 2)
+        while True:
+            line = f.readline()
+            if not line:
+                time.sleep(0.5)
+                continue
+            yield line
+
+def alert(msg: str) -> None:
+    print(f"ALERT: {msg}")
+
+
+def main():
+    db = LogDB()
+    for line in follow(LOG_FILE):
+        ts, host, msg, category, malicious = parse_log_line(line)
+        db.insert_log(ts, host, msg, category, malicious)
+        if malicious:
+            alert(msg)
+
+
+if __name__ == '__main__':
+    main()

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -1,0 +1,54 @@
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Tuple, Any
+
+DB_PATH = Path('logs.db')
+
+class LogDB:
+    def __init__(self, db_path: Path = DB_PATH):
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """CREATE TABLE IF NOT EXISTS logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT,
+                    host TEXT,
+                    message TEXT,
+                    category TEXT,
+                    malicious INTEGER
+            )"""
+        )
+        self.conn.commit()
+
+    def insert_log(self, timestamp: str, host: str, message: str,
+                   category: str, malicious: bool) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO logs (timestamp, host, message, category, malicious)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (timestamp, host, message, category, int(malicious))
+        )
+        self.conn.commit()
+
+    def fetch_logs(self, limit: int = 100) -> Iterable[Tuple[Any, ...]]:
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, timestamp, host, message, category, malicious"
+            " FROM logs ORDER BY id DESC LIMIT ?",
+            (limit,)
+        )
+        return cur.fetchall()
+
+    def count_by_category(self) -> Iterable[Tuple[str, int]]:
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT category, COUNT(*) FROM logs GROUP BY category"
+        )
+        return cur.fetchall()
+
+    def close(self) -> None:
+        self.conn.close()

--- a/log_analyzer/log_parser.py
+++ b/log_analyzer/log_parser.py
@@ -1,0 +1,44 @@
+import re
+from datetime import datetime
+from typing import Tuple
+
+CATEGORY_PATTERNS = {
+    'ERROR': re.compile(r'error|failed', re.IGNORECASE),
+    'WARNING': re.compile(r'warning|deprecated', re.IGNORECASE),
+    'CRITICAL': re.compile(r'critical', re.IGNORECASE),
+    'MALICIOUS': re.compile(r'denied|attack|malware|unauthorized', re.IGNORECASE),
+}
+
+MONTHS = {
+    'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+    'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12
+}
+
+SYSLOG_RE = re.compile(r'^(?P<month>\w{3})\s+(?P<day>\d{1,2})\s+(?P<time>\d{2}:\d{2}:\d{2})\s+(?P<host>\S+)\s+(?P<msg>.*)$')
+
+
+def parse_log_line(line: str) -> Tuple[str, str, str, str, bool]:
+    match = SYSLOG_RE.match(line)
+    if not match:
+        ts = datetime.utcnow().isoformat()
+        host = 'unknown'
+        msg = line.strip()
+    else:
+        month = MONTHS.get(match.group('month'), 1)
+        day = int(match.group('day'))
+        time_part = match.group('time')
+        year = datetime.utcnow().year
+        ts = datetime(year, month, day, *map(int, time_part.split(':'))).isoformat()
+        host = match.group('host')
+        msg = match.group('msg')
+
+    category = 'INFO'
+    malicious = False
+    for cat, regex in CATEGORY_PATTERNS.items():
+        if regex.search(msg):
+            category = cat
+            if cat == 'MALICIOUS':
+                malicious = True
+            break
+
+    return ts, host, msg, category, malicious

--- a/log_analyzer/tui_panel.py
+++ b/log_analyzer/tui_panel.py
@@ -1,0 +1,36 @@
+from rich.console import Console
+from rich.table import Table
+from time import sleep
+from log_analyzer.log_db import LogDB
+
+console = Console()
+
+def display_loop(refresh: int = 2):
+    db = LogDB()
+    try:
+        while True:
+            console.clear()
+            table = Table(title="Resumo de Logs")
+            table.add_column("Categoria")
+            table.add_column("Quantidade", justify="right")
+            for cat, count in db.count_by_category():
+                table.add_row(cat, str(count))
+            console.print(table)
+
+            logs_table = Table(title="Ultimos Eventos")
+            logs_table.add_column("ID")
+            logs_table.add_column("Timestamp")
+            logs_table.add_column("Host")
+            logs_table.add_column("Categoria")
+            logs_table.add_column("Mensagem")
+            for row in db.fetch_logs(limit=10):
+                log_id, ts, host, msg, category, mal = row
+                tag = "*" if mal else ""
+                logs_table.add_row(str(log_id), ts, host, category + tag, msg)
+            console.print(logs_table)
+            sleep(refresh)
+    finally:
+        db.close()
+
+if __name__ == '__main__':
+    display_loop()

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -1,0 +1,28 @@
+from flask import Flask, render_template_string
+from log_analyzer.log_db import LogDB
+
+app = Flask(__name__)
+TEMPLATE = """
+<!doctype html>
+<title>Monitor de Logs</title>
+<h1>Eventos Recentes</h1>
+<table border=1>
+<tr><th>ID</th><th>Timestamp</th><th>Host</th><th>Categoria</th><th>Mensagem</th></tr>
+{% for row in logs %}
+<tr>
+<td>{{row[0]}}</td><td>{{row[1]}}</td><td>{{row[2]}}</td>
+<td>{{row[4]}}{{ '*' if row[5] else '' }}</td><td>{{row[3]}}</td>
+</tr>
+{% endfor %}
+</table>
+"""
+
+@app.route('/')
+def index():
+    db = LogDB()
+    logs = list(db.fetch_logs(limit=50))
+    db.close()
+    return render_template_string(TEMPLATE, logs=logs)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+rich


### PR DESCRIPTION
## Summary
- build simple log database wrapper
- parse syslog lines to categorize events
- continuously collect logs and alert on malicious messages
- show a monitoring panel in the terminal using Rich
- provide a basic web panel with Flask
- add usage instructions and requirements

## Testing
- `pip install -r requirements.txt`
- `python -m log_analyzer.tui_panel | head -n 20`
- `python -m log_analyzer.web_panel > /tmp/web.log 2>&1 & sleep 2; head -n 20 /tmp/web.log; pkill -f log_analyzer.web_panel`

------
https://chatgpt.com/codex/tasks/task_e_686405142bc8832ab3f825c4fa038ae6