### PR TITLE
Centralize config with dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# Caminho para o banco de dados SQLite
+LOG_DB_PATH=logs.db
+
+# Caminho para o arquivo de log lido pelo coletor
+LOG_FILE=rsyslog.log
+
+# Modelos utilizados para classificacao de severidade e deteccao de anomalias
+SEVERITY_MODEL=byviz/bylastic_classification_logs
+ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Caminho para o banco de dados SQLite
+LOG_DB_PATH=logs.db
+
+# Caminho para o arquivo de log lido pelo coletor
+LOG_FILE=rsyslog.log
+
+# Modelos utilizados para classificacao de severidade e deteccao de anomalias
+SEVERITY_MODEL=byviz/bylastic_classification_logs
+ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert

--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ consulte [docs/rsyslog_optimization.md](docs/rsyslog_optimization.md).
 pip install -r requirements.txt
 ```
 
+Copie o arquivo `.env.example` para `.env` e ajuste os caminhos e modelos
+conforme necessario. Todas as configuracoes de banco de dados e modelos LLM sao
+carregadas desse arquivo.
+
 ## Uso
 
-1. Configure o `rsyslog` para gravar seus eventos em `rsyslog.log` na raiz do
+1. Configure o `rsyslog` para gravar seus eventos em `rsyslog.log` (ou no caminho
+   definido na variavel `LOG_FILE` do `.env`) na raiz do
    projeto. Para uma configuracao mais eficiente, consulte o arquivo
    [docs/rsyslog_optimization.md](docs/rsyslog_optimization.md) e salve o
    conteudo sugerido em `/etc/rsyslog.d/50-log_analyzer.conf`.
@@ -67,9 +72,10 @@ A aplicacao web ficará disponivel em `http://localhost:5000`.
 ## Estrutura de diretorios
 
 - `log_analyzer/` - codigo fonte principal
-- `rsyslog.log` - arquivo lido pelo coletor (pode ser alterado no codigo)
-- `logs.db` - banco SQLite criado automaticamente
+- `rsyslog.log` - arquivo lido pelo coletor (configuravel via `.env`)
+- `logs.db` - banco SQLite criado automaticamente (configuravel via `.env`)
 - `schema.sql` - definicao completa da estrutura SQL utilizada
+- `.env.example` - arquivo de exemplo com variaveis de configuracao
 
 ## Alertas
 

--- a/log_analyzer/collector.py
+++ b/log_analyzer/collector.py
@@ -2,8 +2,7 @@ import time
 from pathlib import Path
 from log_analyzer.log_db import LogDB
 from log_analyzer.log_parser import parse_log_line
-
-LOG_FILE = Path('rsyslog.log')
+from log_analyzer.config import LOG_FILE
 
 
 def follow(file_path: Path):

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from .env if present
+load_dotenv()
+
+LOG_DB_PATH = Path(os.getenv("LOG_DB_PATH", "logs.db"))
+LOG_FILE = Path(os.getenv("LOG_FILE", "rsyslog.log"))
+SEVERITY_MODEL = os.getenv(
+    "SEVERITY_MODEL", "byviz/bylastic_classification_logs"
+)
+ANOMALY_MODEL = os.getenv(
+    "ANOMALY_MODEL", "teoogherghi/Log-Analysis-Model-DistilBert"
+)
+

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -2,10 +2,10 @@ import sqlite3
 from pathlib import Path
 from typing import Iterable, Tuple, Any
 
-DB_PATH = Path('logs.db')
+from .config import LOG_DB_PATH
 
 class LogDB:
-    def __init__(self, db_path: Path = DB_PATH):
+    def __init__(self, db_path: Path = LOG_DB_PATH):
         self.db_path = db_path
         self.conn = sqlite3.connect(self.db_path)
         self._init_db()

--- a/log_analyzer/log_parser.py
+++ b/log_analyzer/log_parser.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Tuple
 from functools import lru_cache
 from transformers import pipeline
+from log_analyzer.config import SEVERITY_MODEL, ANOMALY_MODEL
 
 MALICIOUS_RE = re.compile(r'denied|attack|malware|unauthorized', re.IGNORECASE)
 
@@ -25,13 +26,13 @@ ISO_RE = re.compile(
 @lru_cache(maxsize=1)
 def _severity_classifier():
     """Lazy load classifier for severity levels."""
-    return pipeline("text-classification", model="byviz/bylastic_classification_logs")
+    return pipeline("text-classification", model=SEVERITY_MODEL)
 
 
 @lru_cache(maxsize=1)
 def _anomaly_detector():
     """Lazy load anomaly detection model."""
-    return pipeline("text-classification", model="teoogherghi/Log-Analysis-Model-DistilBert")
+    return pipeline("text-classification", model=ANOMALY_MODEL)
 
 
 def parse_log_line(line: str) -> Tuple[str, str, str, str, float, bool]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rich
 transformers
 torch
 logai
+python-dotenv


### PR DESCRIPTION
## Summary
- add `.env` and `.env.example` with database and model settings
- load environment variables via new `config.py`
- update modules to use the centralized configuration
- document usage of `.env`
- add `python-dotenv` to requirements

## Testing
- `python -m compileall -q log_analyzer`
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68642a00163c832aae0ccc454a8a36ca