### PR TITLE
Support PG_* env vars

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,12 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=logs
 
+# Configurações alternativas usando prefixo PG_
+PG_HOST=172.16.187.133
+PG_DB=logs
+PG_USER=vector_store
+PG_PASS=senha_forte
+
 # Caminho para o arquivo de log lido pelo coletor
 LOG_FILE=rsyslog.log
 

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=logs
 
+# Opcoes alternativas usando prefixo PG_
+# PG_HOST=localhost
+# PG_DB=logs
+# PG_USER=postgres
+# PG_PASS=senha
+
 # Caminho para o arquivo de log lido pelo coletor
 LOG_FILE=rsyslog.log
 

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -5,11 +5,12 @@ from dotenv import load_dotenv
 # Load environment variables from .env if present
 load_dotenv()
 
-DB_HOST = os.getenv("DB_HOST", "localhost")
-DB_PORT = int(os.getenv("DB_PORT", "5432"))
-DB_NAME = os.getenv("DB_NAME", "logs")
-DB_USER = os.getenv("DB_USER")
-DB_PASSWORD = os.getenv("DB_PASSWORD")
+# Allow alternative environment variable prefix ``PG_`` for compatibility
+DB_HOST = os.getenv("PG_HOST") or os.getenv("DB_HOST", "localhost")
+DB_PORT = int(os.getenv("PG_PORT") or os.getenv("DB_PORT", "5432"))
+DB_NAME = os.getenv("PG_DB") or os.getenv("DB_NAME", "logs")
+DB_USER = os.getenv("PG_USER") or os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("PG_PASS") or os.getenv("DB_PASSWORD")
 
 LOG_FILE = Path(os.getenv("LOG_FILE", "rsyslog.log"))
 


### PR DESCRIPTION
## Summary
- accept environment variables prefixed with `PG_`
- document alternative variables in `.env.example`
- store provided database credentials in `.env`

## Testing
- `python -m compileall -q . && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68642f0d8a48832a9fcfcbc84c535afb