### PR TITLE
Centralizar dados sensiveis no .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Configuracao unica do banco PostgreSQL
-PG_HOST=172.16.187.133
+PG_HOST=SEU_HOST
 PG_PORT=5432
-PG_DB=resultscan
-PG_USER=vector_store
-PG_PASS=senha_forte
+PG_DB=SEU_DB
+PG_USER=SEU_USUARIO
+PG_PASS=SENHA_DO_DB
 
 # Caminho para o arquivo de log lido pelo coletor
 LOG_FILE=rsyslog.log

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ consulte [docs/rsyslog_optimization.md](docs/rsyslog_optimization.md).
 pip install -r requirements.txt
 ```
 
-Copie o arquivo `.env.example` para `.env`. Todas as variáveis de conexão com
-o PostgreSQL já estão definidas utilizando o prefixo `PG_` e apontam para o
-banco padrão do projeto.
+Copie o arquivo `.env.example` para `.env` e preencha as credenciais do banco.
+Todas as informações sensíveis devem ficar apenas nesse arquivo, já que o
+codigo fonte não define mais valores padrão.
 
 ## Uso
 

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -5,12 +5,12 @@ from dotenv import load_dotenv
 # Load environment variables from .env if present
 load_dotenv()
 
-# Parametros de conexao com valores padrao do banco principal
-DB_HOST = os.getenv("PG_HOST", "172.16.187.133")
-DB_PORT = int(os.getenv("PG_PORT", "5432"))
-DB_NAME = os.getenv("PG_DB", "resultscan")
-DB_USER = os.getenv("PG_USER", "vector_store")
-DB_PASSWORD = os.getenv("PG_PASS", "902grego1989")
+# Parametros de conexao definidos exclusivamente via variáveis de ambiente
+DB_HOST = os.getenv("PG_HOST")
+DB_PORT = int(os.getenv("PG_PORT"))
+DB_NAME = os.getenv("PG_DB")
+DB_USER = os.getenv("PG_USER")
+DB_PASSWORD = os.getenv("PG_PASS")
 
 LOG_FILE = Path(os.getenv("LOG_FILE", "rsyslog.log"))
 


### PR DESCRIPTION
## Summary
- centralize PostgreSQL parameters exclusively in env vars
- clarify in README that only `.env` should store sensitive data
- replace credentials in `.env.example` with placeholders

## Testing
- `python -m compileall -q log_analyzer`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6864333cda4c832aaac0ae4c78afab26