### PR TITLE
Improve rsyslog config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ codigo fonte não define mais valores padrão.
 
 1. Configure o `rsyslog` para gravar seus eventos em `rsyslog.log` (ou no caminho
    definido na variavel `LOG_FILE` do `.env`) na raiz do
-   projeto. Para uma configuracao mais eficiente, consulte o arquivo
-   [docs/rsyslog_optimization.md](docs/rsyslog_optimization.md) e salve o
-   conteudo sugerido em `/etc/rsyslog.d/50-log_analyzer.conf`.
+    projeto. Para uma configuracao mais eficiente, consulte o arquivo
+    [docs/rsyslog_optimization.md](docs/rsyslog_optimization.md) e salve o
+    conteudo sugerido em `/etc/rsyslog.d/50-log_analyzer.conf`. Certifique-se de
+    definir o template antes da `action` para evitar erros de configuracao.
 
    Caso prefira uma configuracao minima, o seguinte exemplo tambem funciona:
 

--- a/docs/rsyslog_optimization.md
+++ b/docs/rsyslog_optimization.md
@@ -25,7 +25,13 @@ main_queue(
 )
 ```
 
-3. Utilize escrita assincrona para reduzir bloqueios de I/O ao enviar eventos para o arquivo lido pelo coletor:
+3. Defina um `template` em formato RFC 3339 para que o parser consiga extrair os campos de forma eficiente **antes** de utilizá-lo:
+
+```conf
+template(name="LogAnalyzerFormat" type="string" string="%timestamp:::date-rfc3339% %HOSTNAME% %syslogtag%%msg%\n")
+```
+
+4. Utilize escrita assincrona para reduzir bloqueios de I/O ao enviar eventos para o arquivo lido pelo coletor:
 
 ```conf
 action(
@@ -34,12 +40,6 @@ action(
     template="LogAnalyzerFormat"
     asyncWriting="on"
 )
-```
-
-4. Defina um `template` em formato RFC 3339 para que o parser consiga extrair os campos de forma eficiente:
-
-```conf
-template(name="LogAnalyzerFormat" type="string" string="%timestamp:::date-rfc3339% %HOSTNAME% %syslogtag%%msg%\n")
 ```
 
 Salve o trecho acima em `/etc/rsyslog.d/50-log_analyzer.conf`, reinicie o `rsyslog` com `sudo systemctl restart rsyslog` e execute o coletor normalmente.


### PR DESCRIPTION
## Summary
- clarify the template must be defined before it is used
- warn about template order in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864391d7a54832aaf6491fb7adb52b5