### PR TITLE
Fix timestamp rendering and silence web panel

### DIFF
--- a/log_analyzer/tui_panel.py
+++ b/log_analyzer/tui_panel.py
@@ -27,7 +27,7 @@ def display_loop(refresh: int = 2):
             for row in db.fetch_logs(limit=10):
                 log_id, ts, host, msg, category, severity, anomaly_score, mal = row
                 tag = "*" if mal else ""
-                logs_table.add_row(str(log_id), ts, host, severity + tag, f"{anomaly_score:.2f}", msg)
+                logs_table.add_row(str(log_id), str(ts), host, severity + tag, f"{anomaly_score:.2f}", msg)
             console.print(logs_table)
             sleep(refresh)
     finally:

--- a/menu.py
+++ b/menu.py
@@ -18,14 +18,24 @@ def handle_sigint(signum, frame):
 signal.signal(signal.SIGINT, handle_sigint)
 
 
-def iniciar(nome: str, modulo: str) -> None:
+def iniciar(nome: str, modulo: str, quiet: bool = False) -> None:
     """Inicia um modulo Python se nao estiver rodando."""
     proc = processes.get(nome)
     if proc and proc.poll() is None:
         print(f"{nome} ja esta em execucao.")
         return
-    print(f"Iniciando {nome}...")
-    processes[nome] = subprocess.Popen([sys.executable, "-m", modulo])
+    if not quiet:
+        print(f"Iniciando {nome}...")
+    stdout = subprocess.DEVNULL if quiet else None
+    stderr = subprocess.DEVNULL if quiet else None
+    processes[nome] = subprocess.Popen(
+        [sys.executable, "-m", modulo], stdout=stdout, stderr=stderr
+    )
+
+
+def iniciar_web() -> None:
+    """Inicia o painel web de forma silenciosa."""
+    iniciar("painel_web", "log_analyzer.web_panel", quiet=True)
 
 
 def finalizar(nome: str) -> None:
@@ -46,7 +56,7 @@ def menu() -> None:
         "2": (finalizar, "coletor"),
         "3": (iniciar, "painel_tui", "log_analyzer.tui_panel"),
         "4": (finalizar, "painel_tui"),
-        "5": (iniciar, "painel_web", "log_analyzer.web_panel"),
+        "5": (iniciar_web,),
         "6": (finalizar, "painel_web"),
     }
 


### PR DESCRIPTION
## Summary
- prevent TUI crash by converting timestamp to string
- hide Flask output when starting the web panel

## Testing
- `python -m py_compile menu.py log_analyzer/tui_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68644561ef60832aaf8eb13d9d191bd3