### PR TITLE
Add semantic anomaly detection module

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,16 @@ Linhas que contenham termos como `denied`, `attack` ou `malware` sao
 classificadas como **MALICIOUS** e geram uma mensagem de alerta no terminal.
 Adicionalmente, entradas cujo `anomaly_score` ultrapassa o valor definido em
 `ANOMALY_THRESHOLD` tambem sao tratadas como suspeitas.
+
+## Detecao de Anomalias Semanticas
+
+Para detectar padroes incomuns no texto dos logs e possivel executar o modulo
+`log_analyzer.semantic_anomaly`. O utilitario gera embeddings utilizando o
+modelo `all-MiniLM-L6-v2` da biblioteca *sentence-transformers* e aplica o
+algoritmo DBSCAN para identificar mensagens atipicas.
+
+```bash
+python -m log_analyzer.semantic_anomaly caminho/para/arquivo.log
+```
+
+Linhas rotuladas com o cluster `-1` sao tratadas como anomalias.

--- a/log_analyzer/semantic_anomaly.py
+++ b/log_analyzer/semantic_anomaly.py
@@ -1,0 +1,55 @@
+import argparse
+from pathlib import Path
+import re
+from typing import List, Tuple
+
+from sentence_transformers import SentenceTransformer
+from sklearn.cluster import DBSCAN
+import numpy as np
+
+# Regex similar ao usado no parser principal para extrair a mensagem
+SYSLOG_RE = re.compile(r'^(?P<month>\w{3})\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s+(?P<msg>.*)$')
+ISO_RE = re.compile(r'^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))\s+\S+\s+(?P<msg>.*)$')
+
+
+def extract_messages(file_path: Path) -> List[str]:
+    messages: List[str] = []
+    with file_path.open('r') as f:
+        for line in f:
+            m = SYSLOG_RE.match(line)
+            if m:
+                messages.append(m.group('msg'))
+                continue
+            m = ISO_RE.match(line)
+            if m:
+                messages.append(m.group('msg'))
+            else:
+                messages.append(line.strip())
+    return messages
+
+
+def detect_anomalies(messages: List[str], eps: float = 0.5, min_samples: int = 5) -> Tuple[np.ndarray, DBSCAN]:
+    """Retorna labels do DBSCAN para cada mensagem."""
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+    embeddings = model.encode(messages, convert_to_numpy=True, show_progress_bar=False)
+    clusterer = DBSCAN(eps=eps, min_samples=min_samples, metric='cosine').fit(embeddings)
+    return clusterer.labels_, clusterer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Deteccao de anomalias semanticas em logs")
+    parser.add_argument('log_file', help='Arquivo de log a ser analisado')
+    parser.add_argument('--eps', type=float, default=0.5, help='Parametro eps do DBSCAN')
+    parser.add_argument('--min-samples', type=int, default=5, help='Parametro min_samples do DBSCAN')
+    args = parser.parse_args()
+
+    messages = extract_messages(Path(args.log_file))
+    labels, _ = detect_anomalies(messages, eps=args.eps, min_samples=args.min_samples)
+
+    for idx, (msg, label) in enumerate(zip(messages, labels)):
+        tag = 'ANOMALIA' if label == -1 else f'cluster {label}'
+        print(f"{idx}\t{tag}\t{msg}")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ torch
 logai
 python-dotenv
 psycopg2-binary
+sentence-transformers
+scikit-learn


### PR DESCRIPTION
## Summary
- add module to detect semantic anomalies using embeddings and DBSCAN
- document the feature in the README
- add `sentence-transformers` and `scikit-learn` to requirements

## Testing
- `python -m py_compile log_analyzer/semantic_anomaly.py`
- `python -m py_compile log_analyzer/*.py`
- `pip install sentence-transformers scikit-learn -q` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6864469025dc832a832e4b75e67ced09