### PR TITLE
Add LLM analysis and pagination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 ANOMALY_THRESHOLD=0.8
 # Modelo para deteccao semantica de anomalias
 SEMANTIC_MODEL=all-MiniLM-L6-v2
+# Parametros para analise opcional via Ollama
+OLLAMA_ENDPOINT=http://localhost:11434/api/generate
+OLLAMA_MODEL=llama2

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ python -m log_analyzer.tui_panel
 ```bash
 python -m log_analyzer.web_panel
 ```
-
-A aplicacao web ficará disponivel em `http://localhost:5000`.
+A aplicacao web ficará disponivel em `http://localhost:5000`. A listagem possui
+paginacao de 100 registros e filtros por severidade.
 Como opcao, execute `python menu.py` para gerenciar todas as funcionalidades a partir de um menu interativo.
 
 ## Estrutura de diretorios
@@ -107,3 +107,14 @@ python -m log_analyzer.semantic_anomaly caminho/para/arquivo.log
 ```
 
 Linhas rotuladas com o cluster `-1` sao tratadas como anomalias.
+
+## Analise com modelos LLM
+
+E possivel enviar uma entrada especifica do banco para analise por um modelo
+compatível com a API do **Ollama**. Configure `OLLAMA_ENDPOINT` e
+`OLLAMA_MODEL` no `.env` e utilize o painel web para acionar a analise ou
+execute manualmente:
+
+```bash
+python -m log_analyzer.llm_analysis ID_DO_LOG
+```

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -24,6 +24,12 @@ ANOMALY_MODEL = os.getenv(
 # Model used for semantic anomaly detection via SentenceTransformers
 SEMANTIC_MODEL = os.getenv("SEMANTIC_MODEL", "all-MiniLM-L6-v2")
 
+# Configuration for optional LLM analysis via Ollama API
+OLLAMA_ENDPOINT = os.getenv(
+    "OLLAMA_ENDPOINT", "http://localhost:11434/api/generate"
+)
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama2")
+
 # Minimum score to treat a log as anomalous. The default value is
 # conservative because the DistilBERT model was trained to separate
 # normal lines from anomalies and may produce high scores for benign

--- a/log_analyzer/llm_analysis.py
+++ b/log_analyzer/llm_analysis.py
@@ -1,0 +1,43 @@
+import os
+import requests
+from typing import List
+
+from .log_db import LogDB
+from .config import OLLAMA_ENDPOINT, OLLAMA_MODEL
+
+
+def analyze_log(log_id: int, context: int = 5) -> str:
+    """Send the log with context to the configured Ollama endpoint."""
+    db = LogDB()
+    logs = db.get_log_with_context(log_id, context=context)
+    db.close()
+    if not logs:
+        return "Log nao encontrado"
+    messages = "\n".join(f"{ts} {host}: {msg}" for _, ts, host, msg in logs)
+    prompt = (
+        "Analise o log abaixo levando em conta o contexto fornecido e "
+        "resuma possiveis causas ou acoes recomendadas.\n" + messages
+    )
+    try:
+        resp = requests.post(
+            OLLAMA_ENDPOINT,
+            json={"model": OLLAMA_MODEL, "prompt": prompt},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response", "")
+    except Exception as exc:
+        return f"Erro ao consultar o modelo: {exc}"
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Analisa um log usando Ollama")
+    parser.add_argument("log_id", type=int, help="ID do log no banco")
+    parser.add_argument(
+        "--context", type=int, default=5, help="Quantidade de linhas de contexto"
+    )
+    args = parser.parse_args()
+    print(analyze_log(args.log_id, context=args.context))

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -48,16 +48,66 @@ class LogDB:
         cur.close()
         self.conn.commit()
 
-    def fetch_logs(self, limit: int = 100) -> Iterable[Tuple[Any, ...]]:
-        cur = self.conn.cursor()
-        cur.execute(
+    def fetch_logs(
+        self,
+        limit: int = 100,
+        page: int | None = None,
+        severity: str | None = None,
+        host: str | None = None,
+        search: str | None = None,
+    ) -> Iterable[Tuple[Any, ...]]:
+        """Return logs optionally paginated and filtered."""
+        query = (
             "SELECT id, timestamp, host, message, category, severity, anomaly_score, malicious, semantic_outlier"
-            " FROM logs ORDER BY id DESC LIMIT %s",
-            (limit,)
+            " FROM logs"
         )
+        clauses: list[str] = []
+        params: list[Any] = []
+        if severity:
+            clauses.append("severity = %s")
+            params.append(severity)
+        if host:
+            clauses.append("host = %s")
+            params.append(host)
+        if search:
+            clauses.append("message ILIKE %s")
+            params.append(f"%{search}%")
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        query += " ORDER BY id DESC"
+        if page is not None:
+            offset = (page - 1) * limit
+            query += " LIMIT %s OFFSET %s"
+            params.extend([limit, offset])
+        else:
+            query += " LIMIT %s"
+            params.append(limit)
+        cur = self.conn.cursor()
+        cur.execute(query, tuple(params))
         rows = cur.fetchall()
         cur.close()
         return rows
+
+    def get_log_with_context(
+        self, log_id: int, context: int = 5
+    ) -> list[Tuple[Any, ...]]:
+        """Return specified log with preceding context lines."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, timestamp, host, message FROM logs WHERE id = %s",
+            (log_id,),
+        )
+        main_log = cur.fetchone()
+        if not main_log:
+            cur.close()
+            return []
+        cur.execute(
+            "SELECT id, timestamp, host, message FROM logs WHERE id < %s ORDER BY id DESC LIMIT %s",
+            (log_id, context),
+        )
+        context_rows = cur.fetchall()[::-1]
+        cur.close()
+        return context_rows + [main_log]
 
     def count_by_category(self) -> Iterable[Tuple[str, int]]:
         cur = self.conn.cursor()

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template_string, jsonify, request
 from log_analyzer.log_db import LogDB
+from log_analyzer.llm_analysis import analyze_log
 
 app = Flask(__name__)
 TEMPLATE = """
@@ -11,29 +12,39 @@ TEMPLATE = """
 </head>
 <body class=\"container my-4\">
 <h1 class=\"mb-4\">Eventos Recentes</h1>
-<div class=\"mb-3\">
-  <span class=\"badge bg-info text-dark\">INFO</span>
-  <span class=\"badge bg-warning text-dark\">WARNING</span>
-  <span class=\"badge bg-danger\">ERROR</span>
-  <span class=\"badge bg-danger text-light\">Ataque</span>
+<div class=\"d-flex justify-content-between mb-3\">
+  <form id=\"filter-form\" class=\"d-flex gap-2\" method=\"get\">
+    <select name=\"severity\" class=\"form-select form-select-sm\">
+      <option value=\"\">Todas</option>
+      <option value=\"INFO\">INFO</option>
+      <option value=\"WARNING\">WARNING</option>
+      <option value=\"ERROR\">ERROR</option>
+    </select>
+    <button class=\"btn btn-sm btn-primary\" type=\"submit\">Filtrar</button>
+  </form>
+  <div>
+    <a href=\"?page={{ page-1 if page>1 else 1 }}{% if severity %}&severity={{ severity }}{% endif %}\" class=\"btn btn-sm btn-secondary\">Anterior</a>
+    <a href=\"?page={{ page+1 }}{% if severity %}&severity={{ severity }}{% endif %}\" class=\"btn btn-sm btn-secondary\">Próximo</a>
+  </div>
 </div>
 <table id=\"log-table\" class=\"table table-striped\">
 <thead>
-<tr><th>ID</th><th>Timestamp</th><th>Host</th><th>Severidade</th><th>Anomalia</th><th>Semantica</th><th>Mensagem</th></tr>
+<tr><th>ID</th><th>Timestamp</th><th>Host</th><th>Severidade</th><th>Anomalia</th><th>Semantica</th><th>Mensagem</th><th></th></tr>
 </thead>
 <tbody>
 {% for row in logs %}
 <tr class="{% if row[7] or row[8] %}table-danger{% endif %}">
 <td>{{row[0]}}</td><td>{{row[1]}}</td><td>{{row[2]}}</td>
-<td class="{{ severity_colors.get(row[5], '') }}">{{row[5]}}{{ '*' if row[7] else '' }}</td><td>{{'%.2f'|format(row[6])}}</td><td>{{ 'sim' if row[8] else 'nao' }}</td><td>{{row[3]}}</td>
+<td class="{{ severity_colors.get(row[5], '') }}">{{row[5]}}{{ '*' if row[7] else '' }}</td><td>{{'%.2f'|format(row[6])}}</td><td>{{ 'sim' if row[8] else 'nao' }}</td><td>{{row[3]}}</td><td><button class="btn btn-sm btn-outline-primary" onclick="analyzeLog({{row[0]}})">Analisar</button></td>
 </tr>
 {% endfor %}
 </tbody>
 </table>
 <script>
 const severityColors = {{ severity_colors | tojson }};
-async function fetchLogs() {
-  const resp = await fetch('/api/logs');
+async function fetchLogs(page = {{ page }}) {
+  const params = new URLSearchParams({page: page, severity: '{{ severity or '' }}'});
+  const resp = await fetch('/api/logs?' + params.toString());
   if (!resp.ok) return;
   const data = await resp.json();
   const tbody = document.querySelector('#log-table tbody');
@@ -48,12 +59,19 @@ async function fetchLogs() {
         <td>${row[6].toFixed(2)}</td>
         <td>${row[8] ? 'sim' : 'nao'}</td>
         <td>${row[3]}</td>
+        <td><button class="btn btn-sm btn-outline-primary" onclick="analyzeLog(${row[0]})">Analisar</button></td>
     `;
     if (row[7] || row[8]) {
         tr.classList.add('table-danger');
     }
     tbody.appendChild(tr);
   }
+}
+async function analyzeLog(id) {
+  const resp = await fetch('/api/analyze/' + id);
+  if (!resp.ok) { alert('erro ao analisar'); return; }
+  const data = await resp.json();
+  alert(data.result);
 }
 fetchLogs();
 setInterval(fetchLogs, 5000);
@@ -64,20 +82,46 @@ setInterval(fetchLogs, 5000);
 
 @app.route('/')
 def index():
+    page = int(request.args.get('page', 1))
+    severity = request.args.get('severity')
     db = LogDB()
-    logs = list(db.fetch_logs(limit=50))
+    logs = list(db.fetch_logs(limit=100, page=page, severity=severity))
     db.close()
     severity_colors = {'INFO': 'text-info', 'WARNING': 'text-warning', 'ERROR': 'text-danger'}
-    return render_template_string(TEMPLATE, logs=logs, severity_colors=severity_colors)
+    return render_template_string(
+        TEMPLATE,
+        logs=logs,
+        severity_colors=severity_colors,
+        page=page,
+        severity=severity,
+    )
 
 
 @app.route('/api/logs')
 def api_logs():
-    limit = int(request.args.get('limit', 50))
+    limit = int(request.args.get('limit', 100))
+    page = int(request.args.get('page', 1))
+    severity = request.args.get('severity')
+    host = request.args.get('host')
+    search = request.args.get('search')
     db = LogDB()
-    logs = list(db.fetch_logs(limit=limit))
+    logs = list(
+        db.fetch_logs(
+            limit=limit,
+            page=page,
+            severity=severity,
+            host=host,
+            search=search,
+        )
+    )
     db.close()
     return jsonify({'logs': logs})
+
+
+@app.route('/api/analyze/<int:log_id>')
+def api_analyze(log_id: int):
+    result = analyze_log(log_id)
+    return jsonify({'result': result})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 psycopg2-binary
 sentence-transformers
 scikit-learn
+requests


### PR DESCRIPTION
## Summary
- integrate optional Ollama API settings in config
- add LLM analysis module
- implement pagination and filters in log database and web panel
- expose analysis option in web interface
- document LLM analysis and pagination
- update dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install requests`

------
https://chatgpt.com/codex/tasks/task_e_68644c1e346c832aaa4f902cfa8f7939