### PR TITLE
Add program column to logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ python -m log_analyzer.tui_panel
 python -m log_analyzer.web_panel
 ```
 A aplicacao web ficará disponivel em `http://localhost:5000`. A listagem possui
-paginacao de 100 registros e filtros por severidade.
+paginacao de 100 registros e filtros por severidade. O nome do software
+responsavel por cada evento tambem é exibido e pode ser utilizado como filtro ao
+clicar sobre ele.
 Como opcao, execute `python menu.py` para gerenciar todas as funcionalidades a partir de um menu interativo.
 O menu tambem permite alternar entre execucao em **CPU** ou **GPU** para a
 analise com modelos LLM.

--- a/log_analyzer/collector.py
+++ b/log_analyzer/collector.py
@@ -25,10 +25,10 @@ def main():
     db = LogDB()
     semantic = OnlineSemanticDetector()
     for line in follow(LOG_FILE):
-        ts, host, msg, severity, anomaly_score, malicious = parse_log_line(line)
+        ts, host, program, msg, severity, anomaly_score, malicious = parse_log_line(line)
         semantic_outlier = semantic.add(msg)
         db.insert_log(
-            ts, host, msg, severity, severity, anomaly_score, malicious, semantic_outlier
+            ts, host, program, msg, severity, severity, anomaly_score, malicious, semantic_outlier
         )
         if malicious or semantic_outlier:
             alert(msg)

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -25,6 +25,7 @@ class LogDB:
                     id SERIAL PRIMARY KEY,
                     timestamp TIMESTAMP,
                     host TEXT,
+                    program TEXT,
                     message TEXT,
                     category TEXT,
                     severity TEXT,
@@ -44,14 +45,14 @@ class LogDB:
         cur.close()
         self.conn.commit()
 
-    def insert_log(self, timestamp: str, host: str, message: str,
+    def insert_log(self, timestamp: str, host: str, program: str, message: str,
                    category: str, severity: str, anomaly_score: float,
                    malicious: bool, semantic_outlier: bool) -> None:
         cur = self.conn.cursor()
         cur.execute(
-            "INSERT INTO logs (timestamp, host, message, category, severity, anomaly_score, malicious, semantic_outlier)"
-            " VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
-            (timestamp, host, message, category, severity, anomaly_score, malicious, semantic_outlier)
+            "INSERT INTO logs (timestamp, host, program, message, category, severity, anomaly_score, malicious, semantic_outlier)"
+            " VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (timestamp, host, program, message, category, severity, anomaly_score, malicious, semantic_outlier)
         )
         cur.close()
         self.conn.commit()
@@ -62,11 +63,12 @@ class LogDB:
         page: int | None = None,
         severity: str | None = None,
         host: str | None = None,
+        program: str | None = None,
         search: str | None = None,
     ) -> Iterable[Tuple[Any, ...]]:
         """Return logs optionally paginated and filtered."""
         query = (
-            "SELECT id, timestamp, host, message, category, severity, anomaly_score, malicious, semantic_outlier"
+            "SELECT id, timestamp, host, program, message, category, severity, anomaly_score, malicious, semantic_outlier"
             " FROM logs"
         )
         clauses: list[str] = []
@@ -77,6 +79,9 @@ class LogDB:
         if host:
             clauses.append("host = %s")
             params.append(host)
+        if program:
+            clauses.append("program = %s")
+            params.append(program)
         if search:
             clauses.append("message ILIKE %s")
             params.append(f"%{search}%")

--- a/log_analyzer/tui_panel.py
+++ b/log_analyzer/tui_panel.py
@@ -21,17 +21,19 @@ def display_loop(refresh: int = 2):
             logs_table.add_column("ID")
             logs_table.add_column("Timestamp")
             logs_table.add_column("Host")
+            logs_table.add_column("Programa")
             logs_table.add_column("Severidade")
             logs_table.add_column("Anomalia")
             logs_table.add_column("Semantica")
             logs_table.add_column("Mensagem")
             for row in db.fetch_logs(limit=10):
-                log_id, ts, host, msg, category, severity, anomaly_score, mal, semantic = row
+                log_id, ts, host, program, msg, category, severity, anomaly_score, mal, semantic = row
                 tag = "*" if mal or semantic else ""
                 logs_table.add_row(
                     str(log_id),
                     str(ts),
                     host,
+                    program,
                     severity + tag,
                     f"{anomaly_score:.2f}",
                     "sim" if semantic else "nao",

--- a/schema.sql
+++ b/schema.sql
@@ -2,6 +2,7 @@ CREATE TABLE logs (
     id SERIAL PRIMARY KEY,
     timestamp TIMESTAMP,
     host TEXT,
+    program TEXT,
     message TEXT,
     category TEXT,
     severity TEXT,


### PR DESCRIPTION
## Summary
- include software generator in DB schema
- expose program in parser and collector
- filter logs by program in the web panel
- show program column in both panels
- document new program filtering feature

## Testing
- `python -m py_compile log_analyzer/*.py menu.py`

------
https://chatgpt.com/codex/tasks/task_e_68645ad1a620832ab14d396315a24eca