### PR TITLE
Implement analyzed_logs table and web panel menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,5 @@ utilize o painel web para acionar a analise ou execute manualmente:
 python -m log_analyzer.llm_analysis ID_DO_LOG
 ```
 O resultado da analise e armazenado na tabela `log_analysis`, ligado ao
-registro original.
+registro original. Alem disso, o log analisado juntamente com o resumo gerado
+eh copiado para a tabela `analyzed_logs` para facilitar consultas futuras.

--- a/log_analyzer/llm_analysis.py
+++ b/log_analyzer/llm_analysis.py
@@ -32,6 +32,7 @@ def analyze_log(log_id: int, context: int = 5) -> str:
         pipe = _get_pipeline()
         result = pipe(prompt, max_new_tokens=200)[0]["generated_text"]
         db.insert_analysis(log_id, result)
+        db.insert_analyzed_log(log_id, result)
         db.close()
         return result
     except Exception as exc:

--- a/schema.sql
+++ b/schema.sql
@@ -17,3 +17,19 @@ CREATE TABLE log_analysis (
     analysis TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE analyzed_logs (
+    id SERIAL PRIMARY KEY,
+    log_id INTEGER UNIQUE REFERENCES logs(id),
+    timestamp TIMESTAMP,
+    host TEXT,
+    program TEXT,
+    message TEXT,
+    category TEXT,
+    severity TEXT,
+    anomaly_score REAL,
+    malicious BOOLEAN,
+    semantic_outlier BOOLEAN,
+    analysis TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- create an `analyzed_logs` table to store logs after LLM analysis
- insert analyzed logs when `analyze_log` is executed
- expose new DB helpers for inserting and fetching analyzed logs
- add navigation menu and page to view analyzed logs in the web panel
- update documentation about the new table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68645cd3d674832aa9980673c985285f