### PR TITLE
Add dynamic toolbar with severity, attack and network stats

### DIFF
--- a/log_analyzer/attack_detection.py
+++ b/log_analyzer/attack_detection.py
@@ -1,0 +1,26 @@
+import re
+from collections import defaultdict
+from typing import Iterable, Dict
+
+ATTACK_PATTERNS = {
+    'ssh-brute-force': re.compile(r'Failed password|invalid user', re.IGNORECASE),
+    'unauthorized-access': re.compile(r'denied|unauthorized', re.IGNORECASE),
+    'malware': re.compile(r'malware', re.IGNORECASE),
+    'attack': re.compile(r'attack', re.IGNORECASE),
+}
+
+
+def classify_attack(message: str) -> str | None:
+    for name, pattern in ATTACK_PATTERNS.items():
+        if pattern.search(message):
+            return name
+    return None
+
+
+def count_attack_types(messages: Iterable[str]) -> Dict[str, int]:
+    counts: Dict[str, int] = defaultdict(int)
+    for msg in messages:
+        atype = classify_attack(msg)
+        if atype:
+            counts[atype] += 1
+    return counts

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -148,6 +148,14 @@ class LogDB:
         cur.close()
         return rows
 
+    def count_by_severity(self) -> Iterable[Tuple[str, int]]:
+        """Return number of logs grouped by severity."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT severity, COUNT(*) FROM logs GROUP BY severity")
+        rows = cur.fetchall()
+        cur.close()
+        return rows
+
     def insert_analysis(self, log_id: int, analysis: str) -> None:
         cur = self.conn.cursor()
         cur.execute(
@@ -212,6 +220,17 @@ class LogDB:
         cur = self.conn.cursor()
         cur.execute(query, tuple(params))
         rows = cur.fetchall()
+        cur.close()
+        return rows
+
+    def fetch_recent_malicious(self, limit: int = 100) -> Iterable[str]:
+        """Return messages flagged as malicious."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT message FROM logs WHERE malicious = TRUE ORDER BY id DESC LIMIT %s",
+            (limit,),
+        )
+        rows = [r[0] for r in cur.fetchall()]
         cur.close()
         return rows
 

--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -14,9 +14,36 @@
     </ul>
   </div>
 </nav>
+<div id="toolbar" class="bg-body-secondary py-2">
+  <div class="container d-flex flex-wrap gap-3 small">
+    <span id="severity-info"></span>
+    <span id="attack-info"></span>
+    <span id="iface-info"></span>
+  </div>
+</div>
 <div class="container my-4">
 {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+const SEVERITY_COLORS = {{ severity_colors | tojson }};
+async function fetchStats() {
+  const resp = await fetch('/api/stats');
+  if (!resp.ok) return;
+  const data = await resp.json();
+  const sev = document.getElementById('severity-info');
+  const attacks = document.getElementById('attack-info');
+  const iface = document.getElementById('iface-info');
+  sev.innerHTML = Object.entries(data.severity).map(
+    ([k,v]) => `<span class="${SEVERITY_COLORS[k] || ''} me-2">${k}: ${v}</span>`
+  ).join(' ');
+  attacks.textContent = Object.entries(data.attacks).map(
+    ([k,v]) => `${k}: ${v}`
+  ).join(' ');
+  iface.textContent = `Ativas: ${data.interfaces.active.join(', ')} | Atividade: ${data.interfaces.activity.join(', ')}`;
+}
+fetchStats();
+setInterval(fetchStats, 5000);
+</script>
 </body>
 </html>

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -1,9 +1,52 @@
 from flask import Flask, render_template, jsonify, request, redirect, url_for
 from log_analyzer.log_db import LogDB
 from log_analyzer.llm_analysis import analyze_log
+from log_analyzer.attack_detection import count_attack_types
+import os
+from pathlib import Path
 
 
 app = Flask(__name__)
+
+SEVERITY_COLORS = {
+    'INFO': 'text-info',
+    'WARNING': 'text-warning',
+    'ERROR': 'text-danger'
+}
+
+
+def get_network_info() -> tuple[list[str], list[str]]:
+    """Return active interfaces and those with traffic."""
+    interfaces = []
+    try:
+        interfaces = os.listdir('/sys/class/net')
+    except Exception:
+        pass
+    active: list[str] = []
+    activity: list[str] = []
+    stats: dict[str, list[str]] = {}
+    try:
+        with open('/proc/net/dev') as f:
+            lines = f.readlines()[2:]
+        for line in lines:
+            parts = line.split()
+            iface = parts[0].strip(':')
+            stats[iface] = parts
+    except Exception:
+        pass
+    for iface in interfaces:
+        try:
+            state = Path(f'/sys/class/net/{iface}/operstate').read_text().strip()
+            if state == 'up':
+                active.append(iface)
+        except Exception:
+            pass
+        if iface in stats:
+            rx = int(stats[iface][1])
+            tx = int(stats[iface][9])
+            if rx > 0 or tx > 0:
+                activity.append(iface)
+    return active, activity
 
 
 @app.route('/')
@@ -19,11 +62,10 @@ def logs_page():
     db = LogDB()
     logs = list(db.fetch_logs(limit=100, page=page, severity=severity, program=program))
     db.close()
-    severity_colors = {'INFO': 'text-info', 'WARNING': 'text-warning', 'ERROR': 'text-danger'}
     return render_template(
         'logs.html',
         logs=logs,
-        severity_colors=severity_colors,
+        severity_colors=SEVERITY_COLORS,
         page=page,
         severity=severity,
         program=program,
@@ -35,6 +77,7 @@ def logs_page():
 def analyzed_page():
     return render_template(
         'analyzed.html',
+        severity_colors=SEVERITY_COLORS,
         menu='analyzed'
     )
 
@@ -70,6 +113,21 @@ def api_logs():
     )
     db.close()
     return jsonify({'logs': logs})
+
+
+@app.route('/api/stats')
+def api_stats():
+    db = LogDB()
+    severity_counts = dict(db.count_by_severity())
+    malicious_msgs = list(db.fetch_recent_malicious(limit=200))
+    db.close()
+    attacks = count_attack_types(malicious_msgs)
+    active, activity = get_network_info()
+    return jsonify({
+        'severity': severity_counts,
+        'attacks': attacks,
+        'interfaces': {'active': active, 'activity': activity}
+    })
 
 
 @app.route('/api/analyze/<int:log_id>')


### PR DESCRIPTION
## Summary
- add DB helpers for severity counts and recent malicious messages
- create attack_detection module for basic attack classification
- gather interface info and overall stats in API
- display stats dynamically on toolbar of web UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68646839d80c832a8b0fbb01ecbee5ba