### PR TITLE
Integrate toolbar stats into navbar

### DIFF
--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -6,21 +6,21 @@
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark mb-4">
-  <div class="container-fluid d-flex justify-content-between">
-    <span class="navbar-brand mb-0 h1">Log Dashboard</span>
-    <ul class="navbar-nav flex-row gap-3">
-      <li class="nav-item"><a href="{{ url_for('logs_page') }}" class="nav-link {% if menu=='logs' %}active text-white{% else %}text-secondary{% endif %}">Logs</a></li>
-      <li class="nav-item"><a href="{{ url_for('analyzed_page') }}" class="nav-link {% if menu=='analyzed' %}active text-white{% else %}text-secondary{% endif %}">Analisados</a></li>
-    </ul>
+  <div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center">
+      <span class="navbar-brand mb-0 h1">Log Dashboard</span>
+      <ul class="navbar-nav flex-row gap-3">
+        <li class="nav-item"><a href="{{ url_for('logs_page') }}" class="nav-link {% if menu=='logs' %}active text-white{% else %}text-secondary{% endif %}">Logs</a></li>
+        <li class="nav-item"><a href="{{ url_for('analyzed_page') }}" class="nav-link {% if menu=='analyzed' %}active text-white{% else %}text-secondary{% endif %}">Analisados</a></li>
+      </ul>
+    </div>
+    <div id="toolbar" class="d-flex flex-wrap gap-3 small mt-2">
+      <span id="severity-info"></span>
+      <span id="attack-info"></span>
+      <span id="iface-info"></span>
+    </div>
   </div>
 </nav>
-<div id="toolbar" class="bg-body-secondary py-2">
-  <div class="container d-flex flex-wrap gap-3 small">
-    <span id="severity-info"></span>
-    <span id="attack-info"></span>
-    <span id="iface-info"></span>
-  </div>
-</div>
 <div class="container my-4">
 {% block content %}{% endblock %}
 </div>


### PR DESCRIPTION
## Summary
- move stats toolbar inside the dark navbar so all info stays in the top bar

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646a9ff548832aad7f3597a0ce6970