### PR TITLE
Improve web panel responsiveness

### DIFF
--- a/log_analyzer/templates/analyzed.html
+++ b/log_analyzer/templates/analyzed.html
@@ -1,12 +1,14 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2 class="mb-4">Logs Analisados</h2>
+<div class="table-responsive">
 <table id="analyzed-table" class="table table-striped">
 <thead>
 <tr><th>ID Original</th><th>Timestamp</th><th>Programa</th><th>Severidade</th><th>Anomalia</th><th>Mensagem</th><th>Resumo</th></tr>
 </thead>
 <tbody></tbody>
 </table>
+</div>
 <script>
 async function fetchAnalyzed(page=1) {
   const resp = await fetch('/api/analyzed?page='+page);

--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Log Dashboard</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>

--- a/log_analyzer/templates/logs.html
+++ b/log_analyzer/templates/logs.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2 class="mb-4">Eventos Recentes</h2>
-<div class="d-flex justify-content-between mb-3">
-  <form id="filter-form" class="d-flex gap-2" method="get">
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+  <form id="filter-form" class="d-flex flex-wrap gap-2" method="get">
     <select name="severity" class="form-select form-select-sm">
       <option value="">Todas</option>
       <option value="INFO">INFO</option>
@@ -11,11 +11,12 @@
     </select>
     <button class="btn btn-sm btn-primary" type="submit">Filtrar</button>
   </form>
-  <div>
+  <div class="d-flex gap-2">
     <a href="?page={{ page-1 if page>1 else 1 }}{% if severity %}&severity={{ severity }}{% endif %}" class="btn btn-sm btn-secondary">Anterior</a>
     <a href="?page={{ page+1 }}{% if severity %}&severity={{ severity }}{% endif %}" class="btn btn-sm btn-secondary">Próximo</a>
   </div>
 </div>
+<div class="table-responsive">
 <table id="log-table" class="table table-striped">
 <thead>
 <tr><th>ID</th><th>Timestamp</th><th>Host</th><th>Programa</th><th>Severidade</th><th>Anomalia</th><th>Semantica</th><th>Mensagem</th><th></th></tr>
@@ -29,6 +30,7 @@
 {% endfor %}
 </tbody>
 </table>
+</div>
 <!-- Modal -->
 <div class="modal fade" id="analysisModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">


### PR DESCRIPTION
## Summary
- add viewport meta tag for smaller screens
- make filter/pagination layout responsive and wrap log table
- wrap analyzed table for small screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68647ee75ef8832ab7b985abea86513a