### PR TITLE
Replace tables with responsive list views

### DIFF
--- a/log_analyzer/templates/analyzed.html
+++ b/log_analyzer/templates/analyzed.html
@@ -1,32 +1,27 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2 class="mb-4">Logs Analisados</h2>
-<div class="table-responsive">
-<table id="analyzed-table" class="table table-striped">
-<thead>
-<tr><th>ID Original</th><th>Timestamp</th><th>Programa</th><th>Severidade</th><th>Anomalia</th><th>Mensagem</th><th>Resumo</th></tr>
-</thead>
-<tbody></tbody>
-</table>
-</div>
+<div id="analyzed-list" class="list-group"></div>
 <script>
 async function fetchAnalyzed(page=1) {
   const resp = await fetch('/api/analyzed?page='+page);
   if (!resp.ok) return;
   const data = await resp.json();
-  const tbody = document.querySelector('#analyzed-table tbody');
-  tbody.innerHTML = '';
+  const list = document.getElementById('analyzed-list');
+  list.innerHTML = '';
   for (const row of data.logs) {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `
-        <td>${row[0]}</td>
-        <td>${row[1]}</td>
-        <td>${row[3]}</td>
-        <td>${row[6]}</td>
-        <td>${row[7].toFixed(2)}</td>
-        <td>${row[4]}</td>
-        <td>${row[10]}</td>`;
-    tbody.appendChild(tr);
+    const item = document.createElement('div');
+    item.className = 'list-group-item small';
+    item.innerHTML = `
+        <div><strong>ID Original:</strong> ${row[0]} - <strong>${row[1]}</strong></div>
+        <div class="d-flex flex-wrap gap-2">
+          <span><strong>Programa:</strong> ${row[3]}</span>
+          <span><strong>Severidade:</strong> ${row[6]}</span>
+          <span><strong>Anomalia:</strong> ${row[7].toFixed(2)}</span>
+        </div>
+        <div class="text-break">${row[4]}</div>
+        <div class="mt-1"><strong>Resumo:</strong> ${row[10]}</div>`;
+    list.appendChild(item);
   }
 }
 fetchAnalyzed();

--- a/log_analyzer/templates/logs.html
+++ b/log_analyzer/templates/logs.html
@@ -16,20 +16,28 @@
     <a href="?page={{ page+1 }}{% if severity %}&severity={{ severity }}{% endif %}" class="btn btn-sm btn-secondary">Próximo</a>
   </div>
 </div>
-<div class="table-responsive">
-<table id="log-table" class="table table-striped">
-<thead>
-<tr><th>ID</th><th>Timestamp</th><th>Host</th><th>Programa</th><th>Severidade</th><th>Anomalia</th><th>Semantica</th><th>Mensagem</th><th></th></tr>
-</thead>
-<tbody>
+<div id="log-list" class="list-group">
 {% for row in logs %}
-<tr class="{% if row[8] or row[9] %}table-danger{% endif %}">
-<td>{{row[0]}}</td><td>{{row[1]}}</td><td>{{row[2]}}</td><td><a href="?program={{row[3]}}">{{row[3]}}</a></td>
-<td class="{{ severity_colors.get(row[6], '') }}">{{row[6]}}{{ '*' if row[8] else '' }}</td><td>{{'%.2f'|format(row[7])}}</td><td>{{ 'sim' if row[9] else 'nao'}}</td><td>{{row[4]}}</td><td><button class="btn btn-sm btn-outline-primary" onclick="analyzeLog({{row[0]}})">Analisar</button></td>
-</tr>
+  <div class="list-group-item small d-flex flex-column flex-lg-row justify-content-between gap-2 {% if row[8] or row[9] %}list-group-item-danger{% endif %}">
+    <div class="flex-grow-1">
+      <div class="d-flex flex-wrap gap-2">
+        <span><strong>ID:</strong> {{row[0]}}</span>
+        <span><strong>{{row[1]}}</strong></span>
+        <span><strong>Host:</strong> {{row[2]}}</span>
+        <span><strong>Programa:</strong> <a href="?program={{row[3]}}">{{row[3]}}</a></span>
+      </div>
+      <div class="d-flex flex-wrap gap-2">
+        <span class="{{ severity_colors.get(row[6], '') }}"><strong>{{row[6]}}{{ '*' if row[8] else '' }}</strong></span>
+        <span><strong>Anomalia:</strong> {{'%.2f'|format(row[7])}}</span>
+        <span><strong>Semântica:</strong> {{ 'sim' if row[9] else 'nao'}}</span>
+      </div>
+      <div class="text-break">{{row[4]}}</div>
+    </div>
+    <div class="mt-2 mt-lg-0">
+      <button class="btn btn-sm btn-outline-primary" onclick="analyzeLog({{row[0]}})">Analisar</button>
+    </div>
+  </div>
 {% endfor %}
-</tbody>
-</table>
 </div>
 <!-- Modal -->
 <div class="modal fade" id="analysisModal" tabindex="-1" aria-hidden="true">
@@ -51,25 +59,31 @@ async function fetchLogs(page = {{ page }}) {
   const resp = await fetch('/api/logs?' + params.toString());
   if (!resp.ok) return;
   const data = await resp.json();
-  const tbody = document.querySelector('#log-table tbody');
-  tbody.innerHTML = '';
+  const list = document.getElementById('log-list');
+  list.innerHTML = '';
   for (const row of data.logs) {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `
-        <td>${row[0]}</td>
-        <td>${row[1]}</td>
-        <td>${row[2]}</td>
-        <td><a href="?program=${row[3]}">${row[3]}</a></td>
-        <td class="${severityColors[row[6]] || ''}">${row[6]}${row[8] ? '*' : ''}</td>
-        <td>${row[7].toFixed(2)}</td>
-        <td>${row[9] ? 'sim' : 'nao'}</td>
-        <td>${row[4]}</td>
-        <td><button class="btn btn-sm btn-outline-primary" onclick="analyzeLog(${row[0]})">Analisar</button></td>
-    `;
-    if (row[8] || row[9]) {
-        tr.classList.add('table-danger');
-    }
-    tbody.appendChild(tr);
+    const item = document.createElement('div');
+    item.className = 'list-group-item small d-flex flex-column flex-lg-row justify-content-between gap-2';
+    if (row[8] || row[9]) item.classList.add('list-group-item-danger');
+    item.innerHTML = `
+        <div class="flex-grow-1">
+          <div class="d-flex flex-wrap gap-2">
+            <span><strong>ID:</strong> ${row[0]}</span>
+            <span><strong>${row[1]}</strong></span>
+            <span><strong>Host:</strong> ${row[2]}</span>
+            <span><strong>Programa:</strong> <a href="?program=${row[3]}">${row[3]}</a></span>
+          </div>
+          <div class="d-flex flex-wrap gap-2">
+            <span class="${severityColors[row[6]] || ''}"><strong>${row[6]}${row[8] ? '*' : ''}</strong></span>
+            <span><strong>Anomalia:</strong> ${row[7].toFixed(2)}</span>
+            <span><strong>Semântica:</strong> ${row[9] ? 'sim' : 'nao'}</span>
+          </div>
+          <div class="text-break">${row[4]}</div>
+        </div>
+        <div class="mt-2 mt-lg-0">
+          <button class="btn btn-sm btn-outline-primary" onclick="analyzeLog(${row[0]})">Analisar</button>
+        </div>`;
+    list.appendChild(item);
   }
 }
 async function analyzeLog(id) {


### PR DESCRIPTION
## Summary
- swap out `<table>` layouts for list-group style lists
- update the JS that fetches data to render items as responsive cards instead of table rows

## Testing
- `python -m compileall -q log_analyzer`
- `python -m log_analyzer.web_panel` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6864805623a8832a83b89d8f1da7783d