### PR TITLE
Add dark/light mode toggle

### DIFF
--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -1,13 +1,14 @@
 <!doctype html>
-<html>
+<html data-bs-theme="dark">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Log Dashboard</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 <body>
-<nav class="navbar navbar-dark bg-dark mb-4">
+<nav id="navbar" class="navbar navbar-dark bg-dark mb-4">
   <div class="container-fluid">
     <div class="d-flex justify-content-between align-items-center">
       <span class="navbar-brand mb-0 h1">Log Dashboard</span>
@@ -20,6 +21,9 @@
       <span id="severity-info"></span>
       <span id="attack-info"></span>
       <span id="iface-info" class="text-light"></span>
+      <button id="theme-toggle" class="btn btn-sm btn-secondary" type="button">
+        <i id="theme-icon" class="bi"></i>
+      </button>
     </div>
   </div>
 </nav>
@@ -46,6 +50,29 @@ async function fetchStats() {
 }
 fetchStats();
 setInterval(fetchStats, 5000);
+const THEME_KEY = 'theme';
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-bs-theme', theme);
+  const nav = document.getElementById('navbar');
+  const icon = document.getElementById('theme-icon');
+  if (theme === 'dark') {
+    nav.classList.add('navbar-dark','bg-dark');
+    nav.classList.remove('navbar-light','bg-light');
+    icon.className = 'bi bi-moon-fill';
+  } else {
+    nav.classList.add('navbar-light','bg-light');
+    nav.classList.remove('navbar-dark','bg-dark');
+    icon.className = 'bi bi-sun-fill';
+  }
+}
+const savedTheme = localStorage.getItem(THEME_KEY) || 'dark';
+applyTheme(savedTheme);
+document.getElementById('theme-toggle').addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-bs-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  localStorage.setItem(THEME_KEY, next);
+  applyTheme(next);
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Bootstrap Icons and theme switch button in the toolbar
- implement JavaScript logic to toggle between dark and light themes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864831819d4832aba04bc7d1d54c1ad