### PR TITLE
Add configurable LLM prompt and enrich log analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,6 @@ ANOMALY_THRESHOLD=0.8
 HUGGINGFACE_MODEL=deepseek-ai/DeepSeek-R1-Distill-Qwen-14B
 # Dispositivo para o pipeline (cpu ou cuda)
 DEVICE_TYPE=cpu
+
+# Instrucao base para a analise de logs com modelo de linguagem
+LLM_PROMPT=Analise o log abaixo levando em conta o contexto fornecido e resuma possiveis causas ou acoes recomendadas. Me entregue o texto traduzido para o Portugues do Brasil (PT-BR).

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ Linhas rotuladas com o cluster `-1` sao tratadas como anomalias.
 ## Analise com modelos LLM
 
 E possivel enviar uma entrada especifica do banco para analise por um modelo
-da **Hugging Face**. Defina `HUGGINGFACE_MODEL` e `DEVICE_TYPE` no `.env` e
-utilize o painel web para acionar a analise ou execute manualmente:
+da **Hugging Face**. Defina `HUGGINGFACE_MODEL`, `DEVICE_TYPE` e `LLM_PROMPT` no `.env`. O texto definido em `LLM_PROMPT` e combinado com informacoes do log (ID, programa, severidade, pontuacao de anomalia e mensagem) para compor o prompt final enviado ao modelo. Utilize o painel web para acionar a analise ou execute manualmente:
 
 ```bash
 python -m log_analyzer.llm_analysis ID_DO_LOG

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -37,6 +37,12 @@ HUGGINGFACE_MODEL = os.getenv(
 # Tipo de dispositivo para o pipeline do Hugging Face: "cpu" ou "cuda"
 DEVICE_TYPE = os.getenv("DEVICE_TYPE", "cpu")
 
+# Instrucao base para compor o prompt enviado ao modelo de linguagem
+LLM_PROMPT = os.getenv(
+    "LLM_PROMPT",
+    "Analise o log abaixo levando em conta o contexto fornecido e resuma possiveis causas ou acoes recomendadas. Me entregue o texto traduzido para o Portugues do Brasil (PT-BR).",
+)
+
 # Minimum score to treat a log as anomalous. The default value is
 # conservative because the DistilBERT model was trained to separate
 # normal lines from anomalies and may produce high scores for benign

--- a/log_analyzer/llm_analysis.py
+++ b/log_analyzer/llm_analysis.py
@@ -2,7 +2,7 @@ from typing import List
 from transformers import pipeline
 
 from .log_db import LogDB
-from .config import HUGGINGFACE_MODEL, DEVICE_TYPE
+from .config import HUGGINGFACE_MODEL, DEVICE_TYPE, LLM_PROMPT
 
 
 _pipe = None
@@ -20,21 +20,44 @@ def analyze_log(log_id: int, context: int = 5) -> str:
     """Analyze the log using a Hugging Face model and store the result."""
     db = LogDB()
     logs = db.get_log_with_context(log_id, context=context)
-    if not logs:
+    main_log = db.fetch_log(log_id)
+    if not logs or not main_log:
         db.close()
         return "Log nao encontrado"
+
     messages = "\n".join(f"{ts} {host}: {msg}" for _, ts, host, msg in logs)
+    (
+        _id,
+        ts,
+        host,
+        program,
+        message,
+        _category,
+        severity,
+        anomaly,
+        _malicious,
+        _semantic,
+    ) = main_log
+
     prompt = (
-        "Analise o log abaixo levando em conta o contexto fornecido e "
-        "resuma possiveis causas ou acoes recomendadas.\n" + messages
+        f"{LLM_PROMPT}\n"
+        f"ID Original: {_id} - {ts}\n"
+        f"Programa: {program}\n"
+        f"Severidade: {severity}\n"
+        f"Anomalia: {anomaly}\n"
+        f"Mensagem: {message}\n\n"
+        f"{messages}"
     )
     try:
         pipe = _get_pipeline()
         result = pipe(prompt, max_new_tokens=200)[0]["generated_text"]
-        db.insert_analysis(log_id, result)
-        db.insert_analyzed_log(log_id, result)
+        analysis_text = (
+            f"Resultado da analise do modelo {HUGGINGFACE_MODEL}:\n{result}"
+        )
+        db.insert_analysis(log_id, analysis_text)
+        db.insert_analyzed_log(log_id, analysis_text)
         db.close()
-        return result
+        return analysis_text
     except Exception as exc:
         db.close()
         return f"Erro ao consultar o modelo: {exc}"

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -127,6 +127,17 @@ class LogDB:
         cur.close()
         return rows
 
+    def fetch_log(self, log_id: int) -> tuple[Any, ...] | None:
+        """Return a single log entry by ID with all fields."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, timestamp, host, program, message, category, severity, anomaly_score, malicious, semantic_outlier FROM logs WHERE id = %s",
+            (log_id,),
+        )
+        row = cur.fetchone()
+        cur.close()
+        return row
+
     def get_log_with_context(
         self, log_id: int, context: int = 5
     ) -> list[Tuple[Any, ...]]:


### PR DESCRIPTION
## Summary
- allow defining the analysis prompt via `LLM_PROMPT` environment variable
- expose the new variable in `config.py`
- extend `log_db` with `fetch_log` to get complete log info
- include log metadata when building the prompt in `llm_analysis`
- clarify README about the new variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686489c8e2e0832ab6bdb58599083b6e