### PR TITLE
Enable custom tokenizer for NIDS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 
 # Modelo usado para deteccao de intrusoes em rede
 NIDS_MODEL=caffeinatedcherrychic/mistral-based-NIDS
+# Tokenizer opcional a ser utilizado pelo NIDS. Defina apenas se o modelo nao
+# fornecer o vocabulario. Ex: bert-base-uncased
+NIDS_TOKENIZER=
 # Arquivo monitorado pelo NIDS
 NET_LOG_FILE=network.log
 

--- a/README.md
+++ b/README.md
@@ -131,3 +131,7 @@ para classificar eventos de rede como ataques DoS, Port Scan, Brute Force ou
 PingScan. Essa versao quantizada requer a biblioteca `bitsandbytes`. As entradas
 sao registradas na tabela `network_events` e podem ser acompanhadas pela aba
 "Trafego de rede" do painel web.
+
+Se o repositório do modelo não incluir arquivos de tokenizer, defina a variável
+de ambiente `NIDS_TOKENIZER` com o nome de um tokenizer compatível, por exemplo
+`bert-base-uncased`.

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -25,6 +25,7 @@ ANOMALY_MODEL = os.getenv(
 NIDS_MODEL = os.getenv(
     "NIDS_MODEL", "caffeinatedcherrychic/mistral-based-NIDS"
 )
+NIDS_TOKENIZER = os.getenv("NIDS_TOKENIZER")
 NET_LOG_FILE = Path(os.getenv("NET_LOG_FILE", "network.log"))
 
 # Model used for semantic anomaly detection via SentenceTransformers

--- a/log_analyzer/network_nids.py
+++ b/log_analyzer/network_nids.py
@@ -3,7 +3,12 @@ from pathlib import Path
 from transformers import pipeline
 
 from log_analyzer.log_db import LogDB
-from log_analyzer.config import NIDS_MODEL, NET_LOG_FILE, DEVICE_TYPE
+from log_analyzer.config import (
+    NIDS_MODEL,
+    NET_LOG_FILE,
+    DEVICE_TYPE,
+    NIDS_TOKENIZER,
+)
 
 
 def follow(path: Path):
@@ -20,7 +25,13 @@ def follow(path: Path):
 
 def main():
     device = 0 if DEVICE_TYPE.lower() == "cuda" else -1
-    clf = pipeline("text-classification", model=NIDS_MODEL, device=device)
+    tokenizer = NIDS_TOKENIZER or NIDS_MODEL
+    clf = pipeline(
+        "text-classification",
+        model=NIDS_MODEL,
+        tokenizer=tokenizer,
+        device=device,
+    )
     db = LogDB()
     try:
         for line in follow(NET_LOG_FILE):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ sentence-transformers
 scikit-learn
 bitsandbytes
 accelerate
+protobuf


### PR DESCRIPTION
## Summary
- allow specifying a tokenizer for the NIDS module
- document new environment variable and dependency
- add protobuf to requirements

## Testing
- `python -m py_compile log_analyzer/config.py log_analyzer/network_nids.py`

------
https://chatgpt.com/codex/tasks/task_e_68648c22c3c0832a90e816aaa2aab313