### PR TITLE
Atualiza README e config para Sniffer.AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,27 @@ eh copiado para a tabela `analyzed_logs` para facilitar consultas futuras.
 
 ## Monitoramento de Tráfego de Rede
 
-Um monitor adicional utiliza o modelo **caffeinatedcherrychic/mistral-based-NIDS**
+Um monitor adicional utiliza o modelo **SilverDragon9/Sniffer.AI**
 para classificar eventos de rede como ataques DoS, Port Scan, Brute Force ou
-PingScan. Essa versao quantizada requer a biblioteca `bitsandbytes`. As entradas
-sao registradas na tabela `network_events` e podem ser acompanhadas pela aba
-"Trafego de rede" do painel web.
+PingScan. As entradas são registradas na tabela `network_events` e podem ser
+acompanhadas pela aba "Trafego de rede" do painel web.
 
 Se o repositório do modelo não incluir arquivos de tokenizer, defina a variável
 de ambiente `NIDS_TOKENIZER` com o nome de um tokenizer compatível, por exemplo
 `bert-base-uncased`.
+
+A integração básica pode ser feita com a biblioteca `transformers`:
+
+```python
+from transformers import pipeline
+
+# Exemplo: classificação com Sniffer.AI
+classifier = pipeline("text-classification", model="SilverDragon9/Sniffer.AI")
+
+log = {
+    # características do fluxo IoT ou rede transformadas em JSON ou vetores
+}
+
+result = classifier(log)
+print(result)  # ex: {'label': 'Scanning', 'score': 0.87}
+```

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -23,7 +23,7 @@ ANOMALY_MODEL = os.getenv(
 
 # Modelo para deteccao de intrusoes em rede
 NIDS_MODEL = os.getenv(
-    "NIDS_MODEL", "caffeinatedcherrychic/mistral-based-NIDS"
+    "NIDS_MODEL", "SilverDragon9/Sniffer.AI"
 )
 NIDS_TOKENIZER = os.getenv("NIDS_TOKENIZER")
 NET_LOG_FILE = Path(os.getenv("NET_LOG_FILE", "network.log"))


### PR DESCRIPTION
## Summary
- set the default NIDS model to `SilverDragon9/Sniffer.AI`
- document how to integrate Sniffer.AI in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68649288ada8832ab21164a633ee7874