### PR TITLE
Improve network traffic page

### DIFF
--- a/log_analyzer/templates/network.html
+++ b/log_analyzer/templates/network.html
@@ -3,6 +3,11 @@
 <h2 class="mb-4">Tráfego de Rede</h2>
 <div id="net-list" class="list-group"></div>
 <script>
+const LABEL_COLORS = {{ label_colors | tojson }};
+function labelClass(name) {
+  const key = name.toLowerCase();
+  return LABEL_COLORS[key] || '';
+}
 async function fetchNetwork(page=1) {
   const resp = await fetch('/api/network?page=' + page);
   if (!resp.ok) return;
@@ -12,10 +17,16 @@ async function fetchNetwork(page=1) {
   for (const row of data.events) {
     const item = document.createElement('div');
     item.className = 'list-group-item small';
+    if (row[3].toLowerCase() !== 'normal') {
+      item.classList.add('list-group-item-danger');
+    }
     item.innerHTML = `
-        <div><strong>ID:</strong> ${row[0]} - <strong>${row[1]}</strong></div>
         <div class="d-flex flex-wrap gap-2">
-          <span><strong>Rotulo:</strong> ${row[3]}</span>
+          <span><strong>ID:</strong> ${row[0]}</span>
+          <span><strong>${row[1]}</strong></span>
+        </div>
+        <div class="d-flex flex-wrap gap-2">
+          <span class="${labelClass(row[3])}"><strong>${row[3]}</strong></span>
           <span><strong>Score:</strong> ${row[4].toFixed(2)}</span>
         </div>
         <div class="text-break">${row[2]}</div>`;

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -14,6 +14,14 @@ SEVERITY_COLORS = {
     'ERROR': 'text-danger'
 }
 
+NIDS_COLORS = {
+    'normal': 'text-success',
+    'dos': 'text-danger',
+    'port scan': 'text-warning',
+    'brute force': 'text-info',
+    'pingscan': 'text-primary'
+}
+
 
 def get_network_info() -> tuple[list[str], list[str]]:
     """Return active interfaces and those with traffic."""
@@ -87,6 +95,7 @@ def network_page():
     return render_template(
         'network.html',
         severity_colors=SEVERITY_COLORS,
+        label_colors=NIDS_COLORS,
         menu='network'
     )
 


### PR DESCRIPTION
## Summary
- add color coding for network event labels
- expose label colors in the web panel

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686541c149c8832a918ac8dedbf9cddb