### PR TITLE
Improve attack visibility in panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Tambem e possivel selecionar a interface de rede utilizada pelo monitoramento.
 
 Linhas que contenham termos como `denied`, `attack` ou `malware` sao
 classificadas como **MALICIOUS** e geram uma mensagem de alerta no terminal.
+Entradas marcadas dessa forma sao categorizadas por tipo de ataque (por
+exemplo `ssh-brute-force` ou `unauthorized-access`) e o resultado fica visivel
+no painel web.
 Adicionalmente, entradas cujo `anomaly_score` ultrapassa o valor definido em
 `ANOMALY_THRESHOLD` tambem sao tratadas como suspeitas.
 

--- a/log_analyzer/templates/logs.html
+++ b/log_analyzer/templates/logs.html
@@ -30,6 +30,7 @@
         <span class="{{ severity_colors.get(row[6], '') }}"><strong>{{row[6]}}{{ '*' if row[8] else '' }}</strong></span>
         <span><strong>Anomalia:</strong> {{'%.2f'|format(row[7])}}</span>
         <span><strong>Semântica:</strong> {{ 'sim' if row[9] else 'nao'}}</span>
+        {% if row[10] %}<span class="badge text-bg-danger">{{ row[10] }}</span>{% endif %}
       </div>
       <div class="text-break">{{row[4]}}</div>
     </div>
@@ -77,6 +78,7 @@ async function fetchLogs(page = {{ page }}) {
             <span class="${severityColors[row[6]] || ''}"><strong>${row[6]}${row[8] ? '*' : ''}</strong></span>
             <span><strong>Anomalia:</strong> ${row[7].toFixed(2)}</span>
             <span><strong>Semântica:</strong> ${row[9] ? 'sim' : 'nao'}</span>
+            ${row[10] ? `<span class="badge text-bg-danger">${row[10]}</span>` : ''}
           </div>
           <div class="text-break">${row[4]}</div>
         </div>


### PR DESCRIPTION
## Summary
- show attack type classification on web panel for malicious logs
- compute attack type in API routes
- update README about attack categories

## Testing
- `python -m py_compile log_analyzer/web_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_6865447f5310832a9aad3729eb932027