### PR TITLE
Improve network traffic page

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,10 @@ eh copiado para a tabela `analyzed_logs` para facilitar consultas futuras.
 
 Um monitor adicional utiliza o modelo definido na variavel `NIDS_MODEL` para
 classificar eventos de rede como ataques DoS, Port Scan, Brute Force ou
-PingScan. As entradas são registradas na tabela `network_events` e podem ser
-acompanhadas pela aba "Trafego de rede" do painel web.
+PingScan. As entradas são registradas na tabela `network_events` com o nome do
+modulo responsavel e podem ser acompanhadas pela aba "Trafego de rede" do painel
+web. A listagem possui paginacao e permite filtrar pelo modulo ao clicar sobre
+ele.
 
 Se o repositório do modelo não incluir arquivos de tokenizer, defina a variável
 de ambiente `NIDS_TOKENIZER` com o nome de um tokenizer compatível, por exemplo

--- a/log_analyzer/network_nids.py
+++ b/log_analyzer/network_nids.py
@@ -33,12 +33,13 @@ def main():
         device=device,
     )
     db = LogDB()
+    module = "network_nids"
     try:
         for line in follow(NET_LOG_FILE):
             result = clf(line)[0]
             label = result.get("label", "")
             score = float(result.get("score", 0.0))
-            db.insert_network_event(line, label, score)
+            db.insert_network_event(line, label, score, module)
             if label.lower() != "normal":
                 print(f"ALERTA NIDS: {label} - {line}")
     finally:

--- a/log_analyzer/templates/network.html
+++ b/log_analyzer/templates/network.html
@@ -1,15 +1,33 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2 class="mb-4">Tráfego de Rede</h2>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+  <form class="d-flex flex-wrap gap-2" method="get">
+    <select name="source" class="form-select form-select-sm">
+      <option value="">Todos</option>
+      {% for s in sources %}
+      <option value="{{s}}" {% if s==source %}selected{% endif %}>{{s}}</option>
+      {% endfor %}
+    </select>
+    <button class="btn btn-sm btn-primary" type="submit">Filtrar</button>
+  </form>
+  <div class="d-flex gap-2">
+    <a href="?page={{ page-1 if page>1 else 1 }}{% if source %}&source={{ source }}{% endif %}" class="btn btn-sm btn-secondary">Anterior</a>
+    <a href="?page={{ page+1 }}{% if source %}&source={{ source }}{% endif %}" class="btn btn-sm btn-secondary">Próximo</a>
+  </div>
+</div>
 <div id="net-list" class="list-group"></div>
 <script>
 const LABEL_COLORS = {{ label_colors | tojson }};
+const startPage = {{ page }};
+const currentSource = "{{ source or '' }}";
 function labelClass(name) {
   const key = name.toLowerCase();
   return LABEL_COLORS[key] || '';
 }
-async function fetchNetwork(page=1) {
-  const resp = await fetch('/api/network?page=' + page);
+async function fetchNetwork(page=startPage) {
+  const params = new URLSearchParams({page: page, source: currentSource});
+  const resp = await fetch('/api/network?' + params.toString());
   if (!resp.ok) return;
   const data = await resp.json();
   const list = document.getElementById('net-list');
@@ -24,6 +42,7 @@ async function fetchNetwork(page=1) {
         <div class="d-flex flex-wrap gap-2">
           <span><strong>ID:</strong> ${row[0]}</span>
           <span><strong>${row[1]}</strong></span>
+          <span><strong>Modulo:</strong> <a href="?source=${row[5]}">${row[5] || 'desconhecido'}</a></span>
         </div>
         <div class="d-flex flex-wrap gap-2">
           <span class="${labelClass(row[3])}"><strong>${row[3]}</strong></span>

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -96,10 +96,18 @@ def analyzed_page():
 
 @app.route('/network')
 def network_page():
+    page = int(request.args.get('page', 1))
+    source = request.args.get('source')
+    db = LogDB()
+    sources = list(db.list_network_sources())
+    db.close()
     return render_template(
         'network.html',
         severity_colors=SEVERITY_COLORS,
         label_colors=NIDS_COLORS,
+        sources=sources,
+        page=page,
+        source=source,
         menu='network'
     )
 
@@ -118,8 +126,9 @@ def api_analyzed():
 def api_network():
     limit = int(request.args.get('limit', 100))
     page = int(request.args.get('page', 1))
+    source = request.args.get('source')
     db = LogDB()
-    events = list(db.fetch_network_events(limit=limit, page=page))
+    events = list(db.fetch_network_events(limit=limit, page=page, source=source))
     db.close()
     return jsonify({'events': events})
 

--- a/schema.sql
+++ b/schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE network_events (
     id SERIAL PRIMARY KEY,
     timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     event TEXT,
+    source TEXT,
     label TEXT,
     score REAL
 );


### PR DESCRIPTION
## Summary
- store the source module in `network_events`
- support module filtering in network API
- expose module filter and pagination in the network page
- show the module name when capturing network packets
- document the new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68654985166c832a86b7a083e26a4a2b