### PR TITLE
Add activity badge notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ A aplicacao web ficará disponivel em `http://localhost:5000`. A listagem possui
 paginacao de 100 registros e filtros por severidade. O nome do software
 responsavel por cada evento tambem é exibido e pode ser utilizado como filtro ao
 clicar sobre ele.
+Quando novos registros chegam em qualquer aba, um pequeno balão "+1" é exibido
+ao lado da guia correspondente para indicar atividade recente.
 Como opcao, execute `python menu.py` para gerenciar todas as funcionalidades a partir de um menu interativo.
 O menu tambem permite alternar entre execucao em **CPU** ou **GPU** para a
 analise com modelos LLM.

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -315,5 +315,29 @@ class LogDB:
         cur.close()
         return rows
 
+    def count_logs(self) -> int:
+        """Return total number of log entries."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM logs")
+        count = cur.fetchone()[0]
+        cur.close()
+        return count
+
+    def count_analyzed_logs(self) -> int:
+        """Return number of analyzed log entries."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM analyzed_logs")
+        count = cur.fetchone()[0]
+        cur.close()
+        return count
+
+    def count_network_events(self) -> int:
+        """Return total number of network events."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM network_events")
+        count = cur.fetchone()[0]
+        cur.close()
+        return count
+
     def close(self) -> None:
         self.conn.close()

--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -13,9 +13,18 @@
     <div class="d-flex justify-content-between align-items-center">
       <span class="navbar-brand mb-0 h1">Log Dashboard</span>
       <ul class="navbar-nav flex-row gap-3">
-        <li class="nav-item"><a href="{{ url_for('logs_page') }}" class="nav-link {% if menu=='logs' %}active{% endif %}">Logs</a></li>
-        <li class="nav-item"><a href="{{ url_for('analyzed_page') }}" class="nav-link {% if menu=='analyzed' %}active{% endif %}">Analisados</a></li>
-        <li class="nav-item"><a href="{{ url_for('network_page') }}" class="nav-link {% if menu=='network' %}active{% endif %}">Trafego de rede</a></li>
+        <li class="nav-item position-relative">
+          <a href="{{ url_for('logs_page') }}" class="nav-link {% if menu=='logs' %}active{% endif %}">Logs</a>
+          <span id="badge-logs" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger d-none">+1</span>
+        </li>
+        <li class="nav-item position-relative">
+          <a href="{{ url_for('analyzed_page') }}" class="nav-link {% if menu=='analyzed' %}active{% endif %}">Analisados</a>
+          <span id="badge-analyzed" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger d-none">+1</span>
+        </li>
+        <li class="nav-item position-relative">
+          <a href="{{ url_for('network_page') }}" class="nav-link {% if menu=='network' %}active{% endif %}">Trafego de rede</a>
+          <span id="badge-network" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger d-none">+1</span>
+        </li>
       </ul>
     </div>
     <div id="toolbar" class="d-flex flex-wrap gap-3 small mt-2 p-2 rounded bg-secondary text-light">
@@ -69,6 +78,37 @@ fetchStats();
 fetchAlerts();
 setInterval(fetchStats, 5000);
 setInterval(fetchAlerts, 5000);
+const COUNT_KEY = 'counts';
+const currentMenu = '{{ menu }}';
+let lastCounts = JSON.parse(localStorage.getItem(COUNT_KEY) || '{}');
+let countsReady = Object.keys(lastCounts).length > 0;
+
+async function fetchCounts() {
+  const resp = await fetch('/api/counts');
+  if (!resp.ok) return;
+  const data = await resp.json();
+  if (!countsReady) {
+    lastCounts = data;
+    countsReady = true;
+    localStorage.setItem(COUNT_KEY, JSON.stringify(lastCounts));
+    return;
+  }
+  for (const key of ['logs','analyzed','network']) {
+    const diff = data[key] - (lastCounts[key] || 0);
+    const badge = document.getElementById('badge-' + key);
+    if (diff > 0 && currentMenu !== key) {
+      badge.textContent = '+' + diff;
+      badge.classList.remove('d-none');
+    } else if (currentMenu === key) {
+      lastCounts[key] = data[key];
+      badge.classList.add('d-none');
+    }
+  }
+  localStorage.setItem(COUNT_KEY, JSON.stringify(lastCounts));
+}
+
+fetchCounts();
+setInterval(fetchCounts, 5000);
 const THEME_KEY = 'theme';
 function applyTheme(theme) {
   document.documentElement.setAttribute('data-bs-theme', theme);

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -187,6 +187,19 @@ def api_alerts():
     return jsonify({'alerts': alerts})
 
 
+@app.route('/api/counts')
+def api_counts():
+    """Return total counts for logs, analyzed logs and network events."""
+    db = LogDB()
+    counts = {
+        'logs': db.count_logs(),
+        'analyzed': db.count_analyzed_logs(),
+        'network': db.count_network_events(),
+    }
+    db.close()
+    return jsonify(counts)
+
+
 @app.route('/api/analyze/<int:log_id>')
 def api_analyze(log_id: int):
     result = analyze_log(log_id)


### PR DESCRIPTION
## Summary
- notify about new items with `+1` badges on each tab
- track log, analysis and network event counts on the server
- show badge when there are new entries
- document the new activity indicator in the README

## Testing
- `python -m py_compile log_analyzer/log_db.py log_analyzer/web_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68654f140c34832ab0b657a3abe12019