### PR TITLE
Add network event analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ modulo responsavel e podem ser acompanhadas pela aba "Trafego de rede" do painel
 web. A listagem possui paginacao e permite filtrar pelo modulo ao clicar sobre
 ele.
 
+Eventos de rede também podem ser enviados para análise utilizando o mesmo
+modelo configurado para os logs. O resultado fica gravado nas tabelas
+`network_analysis` e `analyzed_network_events`, aparecendo na aba "Analisados"
+em seção separada dos logs.
+
 Se o repositório do modelo não incluir arquivos de tokenizer, defina a variável
 de ambiente `NIDS_TOKENIZER` com o nome de um tokenizer compatível, por exemplo
 `bert-base-uncased`.

--- a/log_analyzer/templates/analyzed.html
+++ b/log_analyzer/templates/analyzed.html
@@ -1,15 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2 class="mb-4">Logs Analisados</h2>
-<div id="analyzed-list" class="list-group"></div>
+<h2 class="mb-4">Registros Analisados</h2>
+<h5>Logs</h5>
+<div id="analyzed-log-list" class="list-group mb-4"></div>
+<h5>Pacotes de Rede</h5>
+<div id="analyzed-net-list" class="list-group"></div>
 <script>
 async function fetchAnalyzed(page=1) {
-  const resp = await fetch('/api/analyzed?page='+page);
-  if (!resp.ok) return;
-  const data = await resp.json();
-  const list = document.getElementById('analyzed-list');
-  list.innerHTML = '';
-  for (const row of data.logs) {
+  const respLogs = await fetch('/api/analyzed?page='+page);
+  const respNet = await fetch('/api/analyzed_network?page='+page);
+  if (!respLogs.ok || !respNet.ok) return;
+  const dataLogs = await respLogs.json();
+  const dataNet = await respNet.json();
+  const listLogs = document.getElementById('analyzed-log-list');
+  const listNet = document.getElementById('analyzed-net-list');
+  listLogs.innerHTML = '';
+  listNet.innerHTML = '';
+  for (const row of dataLogs.logs) {
     const item = document.createElement('div');
     item.className = 'list-group-item small';
     item.innerHTML = `
@@ -21,7 +28,21 @@ async function fetchAnalyzed(page=1) {
         </div>
         <div class="text-break">${row[4]}</div>
         <div class="mt-1"><strong>Resumo:</strong> ${row[10]}</div>`;
-    list.appendChild(item);
+    listLogs.appendChild(item);
+  }
+  for (const row of dataNet.events) {
+    const item = document.createElement('div');
+    item.className = 'list-group-item small';
+    item.innerHTML = `
+        <div><strong>ID Evento:</strong> ${row[0]} - <strong>${row[1]}</strong></div>
+        <div class="d-flex flex-wrap gap-2">
+          <span><strong>Modulo:</strong> ${row[5] || 'desconhecido'}</span>
+          <span><strong>Classificação:</strong> ${row[3]}</span>
+          <span><strong>Score:</strong> ${row[4].toFixed(2)}</span>
+        </div>
+        <div class="text-break">${row[2]}</div>
+        <div class="mt-1"><strong>Resumo:</strong> ${row[6]}</div>`;
+    listNet.appendChild(item);
   }
 }
 fetchAnalyzed();

--- a/log_analyzer/templates/network.html
+++ b/log_analyzer/templates/network.html
@@ -17,6 +17,18 @@
   </div>
 </div>
 <div id="net-list" class="list-group"></div>
+<!-- Modal reuse -->
+<div class="modal fade" id="analysisModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Resultado da Análise</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="analysis-content"></div>
+    </div>
+  </div>
+</div>
 <script>
 const LABEL_COLORS = {{ label_colors | tojson }};
 const startPage = {{ page }};
@@ -48,9 +60,20 @@ async function fetchNetwork(page=startPage) {
           <span class="${labelClass(row[3])}"><strong>${row[3]}</strong></span>
           <span><strong>Score:</strong> ${row[4].toFixed(2)}</span>
         </div>
-        <div class="text-break">${row[2]}</div>`;
+        <div class="text-break">${row[2]}</div>
+        <div class="mt-2"><button class="btn btn-sm btn-outline-primary" onclick="analyzeNet(${row[0]})">Analisar</button></div>`;
     list.appendChild(item);
   }
+}
+
+async function analyzeNet(id) {
+  const resp = await fetch('/api/analyze_network/' + id);
+  if (!resp.ok) { alert('erro ao analisar'); return; }
+  const data = await resp.json();
+  const modalBody = document.getElementById('analysis-content');
+  modalBody.textContent = data.result;
+  const modal = new bootstrap.Modal(document.getElementById('analysisModal'));
+  modal.show();
 }
 fetchNetwork();
 setInterval(fetchNetwork, 5000);

--- a/schema.sql
+++ b/schema.sql
@@ -42,3 +42,22 @@ CREATE TABLE network_events (
     label TEXT,
     score REAL
 );
+
+CREATE TABLE network_analysis (
+    id SERIAL PRIMARY KEY,
+    event_id INTEGER REFERENCES network_events(id),
+    analysis TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE analyzed_network_events (
+    id SERIAL PRIMARY KEY,
+    event_id INTEGER UNIQUE REFERENCES network_events(id),
+    timestamp TIMESTAMP,
+    event TEXT,
+    label TEXT,
+    score REAL,
+    source TEXT,
+    analysis TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- support analysis of network events with a new database schema
- expose API endpoints to fetch/analyze network packets
- update the dashboard to analyze packets and show analyzed network data
- document network analysis in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68655266eec8832ab4da21bae3e851be