### PR TITLE
Add docker-compose for Elasticsearch

### DIFF
--- a/Elasticsearch/docker-compose.yml
+++ b/Elasticsearch/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    ports:
+      - "9200:9200"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - esnet
+volumes:
+  esdata:
+networks:
+  esnet:


### PR DESCRIPTION
## Summary
- provide docker-compose configuration to launch a single-node Elasticsearch container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865590690a8832aac010c1300a6ca35