### PR TITLE
Reorganize toolbar with network info

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Este projeto coleta logs gerados pelo `rsyslog`, armazena em um banco PostgreSQL
    ```bash
    python -m log_analyzer.web_panel
    ```
-   A aplicação ficará disponível em `http://localhost:5000` com paginação de 100 registros, filtros por severidade e busca textual utilizando o Elasticsearch. O nome do programa é exibido e pode ser usado como filtro ao clicar. Quando novos registros chegam, um balão "+1" indica atividade recente.
+   A aplicação ficará disponível em `http://localhost:5000` com paginação de 100 registros, filtros por severidade e busca textual utilizando o Elasticsearch. O nome do programa é exibido e pode ser usado como filtro ao clicar. Quando novos registros chegam, um balão "+1" indica atividade recente. A barra superior mostra os totais por severidade e, na aba "Tráfego de rede", exibe também a contagem de eventos classificados pelo NIDS.
 4. Opcionalmente execute `python menu.py` para controlar todas as funções a partir de um menu interativo (incluindo troca entre **CPU** e **GPU** e seleção da interface de rede).
 
 ## Personalizando modelos

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -477,5 +477,13 @@ class LogDB:
         cur.close()
         return count
 
+    def count_network_by_label(self) -> Iterable[Tuple[str, int]]:
+        """Return number of network events grouped by label."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT label, COUNT(*) FROM network_events GROUP BY label")
+        rows = cur.fetchall()
+        cur.close()
+        return rows
+
     def close(self) -> None:
         self.conn.close()

--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -29,6 +29,7 @@
     </div>
     <div id="toolbar" class="d-flex flex-wrap gap-3 small mt-2 p-2 rounded bg-secondary text-light">
       <span id="severity-info"></span>
+      <span id="nids-info"></span>
       <span id="attack-info"></span>
       <span id="alert-info" class="text-danger"></span>
       <span id="iface-info"></span>
@@ -44,11 +45,13 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 const SEVERITY_COLORS = {{ severity_colors | tojson }};
+const LABEL_COLORS = {{ label_colors | default({}, true) | tojson }};
 async function fetchStats() {
   const resp = await fetch('/api/stats');
   if (!resp.ok) return;
   const data = await resp.json();
   const sev = document.getElementById('severity-info');
+  const nids = document.getElementById('nids-info');
   const attacks = document.getElementById('attack-info');
   const iface = document.getElementById('iface-info');
   sev.innerHTML = Object.entries(data.severity).map(
@@ -56,6 +59,9 @@ async function fetchStats() {
   ).join(' ');
   attacks.textContent = Object.entries(data.attacks).map(
     ([k,v]) => `${k}: ${v}`
+  ).join(' ');
+  nids.innerHTML = Object.entries(data.network_labels || {}).map(
+    ([k,v]) => `<span class="${LABEL_COLORS[k.toLowerCase()] || ''} me-2">${k}: ${v}</span>`
   ).join(' ');
   iface.textContent = `Ativas: ${data.interfaces.active.join(', ')} | Atividade: ${data.interfaces.activity.join(', ')}`;
 }

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -172,13 +172,15 @@ def api_stats():
     db = LogDB()
     severity_counts = dict(db.count_by_severity())
     malicious_msgs = list(db.fetch_recent_malicious(limit=200))
+    label_counts = dict(db.count_network_by_label())
     db.close()
     attacks = count_attack_types(malicious_msgs)
     active, activity = get_network_info()
     return jsonify({
         'severity': severity_counts,
         'attacks': attacks,
-        'interfaces': {'active': active, 'activity': activity}
+        'interfaces': {'active': active, 'activity': activity},
+        'network_labels': label_counts
     })
 
 


### PR DESCRIPTION
## Summary
- reorganize the toolbar adding a new slot for network statistics
- expose `count_network_by_label` from the database
- return network counts in `/api/stats`
- display those numbers in the base template
- document the updated toolbar

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68655bb57220832a973208e0eb6b89e3