### PR TITLE
Improve network traffic label colors

### DIFF
--- a/log_analyzer/templates/network.html
+++ b/log_analyzer/templates/network.html
@@ -48,7 +48,9 @@ async function fetchNetwork(page=startPage) {
     const item = document.createElement('div');
     item.className = 'list-group-item small d-flex flex-column flex-lg-row justify-content-between gap-2';
     if (row[3].toLowerCase() !== 'normal') {
-      item.classList.add('list-group-item-danger');
+      // Use a warning background for suspicious events to avoid very strong
+      // colors when many entries are present
+      item.classList.add('list-group-item-warning');
     }
     item.innerHTML = `
         <div class="flex-grow-1">
@@ -58,7 +60,7 @@ async function fetchNetwork(page=startPage) {
             <span><strong>Modulo:</strong> <a href="?source=${row[5]}">${row[5] || 'desconhecido'}</a></span>
           </div>
           <div class="d-flex flex-wrap gap-2">
-            <span class="${labelClass(row[3])}"><strong>${row[3]}</strong></span>
+            <span class="${labelClass(row[3])}">${row[3]}</span>
             <span><strong>Score:</strong> ${row[4].toFixed(2)}</span>
           </div>
           <div class="text-break">${row[2]}</div>

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -16,11 +16,13 @@ SEVERITY_COLORS = {
 }
 
 NIDS_COLORS = {
-    'normal': 'text-success',
-    'dos': 'text-danger',
-    'port scan': 'text-warning',
-    'brute force': 'text-info',
-    'pingscan': 'text-primary'
+    # Classes used to color network labels. Using Bootstrap badge styles
+    # provides good contrast in both light and dark themes.
+    'normal': 'badge text-bg-secondary',
+    'dos': 'badge text-bg-danger',
+    'port scan': 'badge text-bg-warning',
+    'brute force': 'badge text-bg-info',
+    'pingscan': 'badge text-bg-primary'
 }
 
 


### PR DESCRIPTION
## Summary
- switch NIDS colors to Bootstrap badge styles
- lighten background for suspicious events
- display NIDS labels as badges

## Testing
- `python -m py_compile log_analyzer/web_panel.py`
- `flake8 || true`
- `python log_analyzer/web_panel.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68658bea3340832aa6422dede5a1756a