### PR TITLE
Add unified Docker Compose for Elasticsearch and Graylog

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Este projeto coleta logs gerados pelo `rsyslog`, armazena em um banco PostgreSQL
 ## Requisitos
 - Python 3.8 ou superior.
 - Dependências listadas em `requirements.txt` (inclui `bitsandbytes` para modelos quantizados).
-- Uma instância do **Elasticsearch** acessível no endereço configurado em `ES_URL`.
+- Uma instância do **Elasticsearch** acessível em `ES_URL` (pode ser iniciada com `docker compose up -d`).
 - Banco PostgreSQL disponível para receber as tabelas definidas em `schema.sql`.
 
 ## Instalação
@@ -40,7 +40,7 @@ Este projeto coleta logs gerados pelo `rsyslog`, armazena em um banco PostgreSQL
    ```bash
    pip install -r requirements.txt
    ```
-3. Copie `.env.example` para `.env` e preencha as credenciais do banco e o endereço do Elasticsearch.
+3. Copie `.env.example` para `.env` e preencha as credenciais do banco e do Elasticsearch (caso utilize uma instância externa).
 4. Crie o banco de dados e aplique o script `schema.sql`.
 5. Ajuste o `rsyslog` conforme [docs/rsyslog_optimization.md](docs/rsyslog_optimization.md) para registrar os eventos em `rsyslog.log` (ou caminho definido em `LOG_FILE`).
 
@@ -104,10 +104,10 @@ print(result)  # ex: {'label': 'Scanning', 'score': 0.87}
 O dispositivo de rede utilizado na captura é configurado em `NET_INTERFACE` e é possível enviar eventos para análise utilizando o mesmo modelo de logs, armazenando o resultado em `network_analysis` e `analyzed_network_events`.
 
 ## Integração com Graylog
-O diretório `Graylog` contém um `docker-compose.yml` com todos os serviços necessários para executar o Graylog (MongoDB, Elasticsearch e PostgreSQL). As credenciais do banco são lidas do arquivo `.env` do projeto. Para iniciar execute:
+O projeto traz um `docker-compose.yml` unificado que inicia o **Elasticsearch** e o ambiente do Graylog (MongoDB e PostgreSQL). As credenciais do banco são lidas do arquivo `.env`. Para iniciar execute:
 
 ```bash
-docker compose -f Graylog/docker-compose.yml up -d
+docker compose up -d
 ```
 
 A interface ficará disponível em `http://localhost:9000` e os parâmetros adicionais estão definidos em `Graylog/graylog.conf`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+version: '3.8'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    ports:
+      - "9200:9200"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - lognet
+
+  mongo:
+    image: mongo:6.0
+    container_name: graylog_mongo
+    volumes:
+      - mongo_data:/data/db
+    networks:
+      - lognet
+
+  postgres:
+    image: postgres:15
+    container_name: postgres
+    environment:
+      - POSTGRES_DB=${PG_DB:-logs}
+      - POSTGRES_USER=${PG_USER:-logs}
+      - POSTGRES_PASSWORD=${PG_PASS:-logs}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - lognet
+
+  graylog:
+    image: graylog/graylog:5.2
+    container_name: graylog
+    depends_on:
+      - mongo
+      - elasticsearch
+      - postgres
+    environment:
+      - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
+      - GRAYLOG_ROOT_PASSWORD_SHA2=e3afed0047b08059d0fada10f400c1e5af3403e1ff8eb44b4fa8d13d40e86b35
+      - GRAYLOG_HTTP_EXTERNAL_URI=http://localhost:9000/
+      - GRAYLOG_MONGODB_URI=mongodb://mongo:27017/graylog
+      - GRAYLOG_ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    volumes:
+      - ./Graylog/graylog.conf:/usr/share/graylog/data/config/graylog.conf
+      - ./Graylog/postgres_input.conf:/etc/graylog/postgres_input.conf
+    networks:
+      - lognet
+    restart: always
+    ports:
+      - "9000:9000"
+      - "12201:12201/udp"
+      - "1514:1514"
+
+volumes:
+  esdata:
+  mongo_data:
+  pgdata:
+
+networks:
+  lognet:


### PR DESCRIPTION
## Summary
- add a docker-compose.yml at repository root to run Elasticsearch and Graylog stack together
- update README instructions to use the new compose file and clarify environment setup

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686591d24784832ab732061da5ff27a8