### PR TITLE
Fix anomaly score formatting

### DIFF
--- a/log_analyzer/templates/logs.html
+++ b/log_analyzer/templates/logs.html
@@ -28,7 +28,7 @@
       </div>
       <div class="d-flex flex-wrap gap-2">
         <span class="{{ severity_colors.get(row[6], '') }}"><strong>{{row[6]}}{{ '*' if row[8] else '' }}</strong></span>
-        <span><strong>Anomalia:</strong> {{'%.2f'|format(row[7])}}</span>
+        <span><strong>Anomalia:</strong> {{ '%.2f' | format(row[7]|float) }}</span>
         <span><strong>Semântica:</strong> {{ 'sim' if row[9] else 'nao'}}</span>
         {% if row[10] %}<span class="badge text-bg-danger">{{ row[10] }}</span>{% endif %}
       </div>


### PR DESCRIPTION
## Summary
- ensure anomaly score is formatted as a float when rendering logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865988dc960832ab3d814563c6e93d7