### PR TITLE
Fix Graylog node ID persistence docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,16 @@ docker compose up -d
 ```
 
 A interface ficará disponível em `http://localhost:9000` e os parâmetros adicionais estão definidos em `Graylog/graylog.conf`.
+
+Caso o contêiner reinicie com erro de permissão ao persistir o **Node ID** do
+Graylog, defina `GRAYLOG_NODE_ID_FILE` para um local gravável. Um exemplo é
+`/usr/share/graylog/data/config/node-id`, que já possui permissões adequadas:
+
+```yaml
+graylog:
+  environment:
+    - GRAYLOG_NODE_ID_FILE=/usr/share/graylog/data/config/node-id
+```
+
+Com esse ajuste o arquivo é criado corretamente e o serviço passa a iniciar
+normalmente.

--- a/docs/graylog_node_id.md
+++ b/docs/graylog_node_id.md
@@ -1,0 +1,19 @@
+# Resolucao para erro de Node ID no Graylog
+
+Se o container do Graylog reiniciar repetidamente com mensagens semelhantes a
+`AccessDeniedException: /etc/graylog/server`, significa que o processo nao
+consegue escrever o arquivo `node-id`. Defina a variavel `GRAYLOG_NODE_ID_FILE`
+para um diretorio gravavel. Um caminho recomendado eh
+`/usr/share/graylog/data/config/node-id`.
+
+Exemplo de configuracao no `docker-compose.yml`:
+
+```yaml
+services:
+  graylog:
+    environment:
+      - GRAYLOG_NODE_ID_FILE=/usr/share/graylog/data/config/node-id
+```
+
+Esse diretorio ja existe dentro da imagem e possui permissoes suficientes para
+criar o arquivo, evitando que o servico encerre por `NodeIdPersistenceException`.


### PR DESCRIPTION
## Summary
- document how to configure GRAYLOG_NODE_ID_FILE for writable location
- add note about restart loop in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865a18f2e38832a8956e68078043c7f