### PR TITLE
Add Graylog admin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ PG_DB=SEU_DB
 PG_USER=SEU_USUARIO
 PG_PASS=SENHA_DO_DB
 
+# Credenciais do admin do Graylog
+GRAYLOG_ROOT_USERNAME=admin
+GRAYLOG_ROOT_PASSWORD_SHA2=superSenhaComplexa123!
+
 # URL de conexao para o Elasticsearch
 ES_URL=http://localhost:9200
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ print(result)  # ex: {'label': 'Scanning', 'score': 0.87}
 O dispositivo de rede utilizado na captura é configurado em `NET_INTERFACE` e é possível enviar eventos para análise utilizando o mesmo modelo de logs, armazenando o resultado em `network_analysis` e `analyzed_network_events`.
 
 ## Integração com Graylog
-O projeto disponibiliza um `docker-compose.yml` na raiz com todos os serviços necessários para executar o Graylog (MongoDB e Elasticsearch). Ele reutiliza o PostgreSQL já configurado através das variáveis presentes no `.env`. Para iniciar execute:
+O projeto disponibiliza um `docker-compose.yml` na raiz com todos os serviços necessários para executar o Graylog (MongoDB e Elasticsearch). Ele reutiliza o PostgreSQL já configurado através das variáveis presentes no `.env`. Defina em `GRAYLOG_ROOT_USERNAME` e `GRAYLOG_ROOT_PASSWORD_SHA2` as credenciais do administrador. Para iniciar execute:
 
 ```bash
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,9 +57,11 @@ services:
       GRAYLOG_MONGODB_URI: "mongodb://mongodb:27017/graylog"
       GRAYLOG_ELASTICSEARCH_HOSTS: "http://opensearch:9200"
       GRAYLOG_PASSWORD_SECRET: "muitoseguraepepper1234567890"
+      # Usuario e senha definidos no .env
+      GRAYLOG_ROOT_USERNAME: "${GRAYLOG_ROOT_USERNAME}"
       # Coloque o SHA2 da senha do admin:
-      # unix: echo -n "admin123" | sha256sum | cut -d " " -f1
-      GRAYLOG_ROOT_PASSWORD_SHA2: "superSenhaComplexa123!"
+      # unix: echo -n "${GRAYLOG_ROOT_PASSWORD_SHA2}" | sha256sum | cut -d " " -f1
+      GRAYLOG_ROOT_PASSWORD_SHA2: "${GRAYLOG_ROOT_PASSWORD_SHA2}"
       GRAYLOG_REPORT_DISABLE_SANDBOX: "true"
     ports:
       - "9000:9000"


### PR DESCRIPTION
## Summary
- configure Graylog admin user credentials through environment variables
- document new variables in README
- update example `.env` file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686692acdca8832a9117ca1dd7d5caea