### PR TITLE
Mudar para Graylog Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ print(result)  # ex: {'label': 'Scanning', 'score': 0.87}
 O dispositivo de rede utilizado na captura é configurado em `NET_INTERFACE` e é possível enviar eventos para análise utilizando o mesmo modelo de logs, armazenando o resultado em `network_analysis` e `analyzed_network_events`.
 
 ## Integração com Graylog
-O projeto disponibiliza um `docker-compose.yml` na raiz com todos os serviços necessários para executar o Graylog (MongoDB e Elasticsearch). Ele reutiliza o PostgreSQL já configurado através das variáveis presentes no `.env`. Defina em `GRAYLOG_ROOT_USERNAME` e `GRAYLOG_ROOT_PASSWORD_SHA2` as credenciais do administrador. Para iniciar execute:
+O projeto disponibiliza um `docker-compose.yml` na raiz com todos os serviços necessários para executar o Graylog Community (MongoDB e Elasticsearch). Ele reutiliza o PostgreSQL já configurado através das variáveis presentes no `.env`. Defina em `GRAYLOG_ROOT_USERNAME` e `GRAYLOG_ROOT_PASSWORD_SHA2` as credenciais do administrador. Para iniciar execute:
 
 ```bash
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
       - graylog
 
   graylog:
-    image: graylog/graylog-enterprise:6.1
+    # Versão Community do Graylog
+    image: graylog/graylog:6.1
     container_name: graylog
     restart: on-failure
     depends_on:


### PR DESCRIPTION
## Summary
- usar a imagem `graylog/graylog` no docker-compose
- documentar que o compose utiliza Graylog Community

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686696a4fa00832a950d603b92e8d73e