### PR TITLE
Add Graylog integration for logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ OPENSEARCH_INITIAL_ADMIN_PASSWORD=superSenhaComplexa123!
 # URL de conexao para o Elasticsearch
 ES_URL=http://localhost:9200
 
+# Endpoint GELF para envio ao Graylog (opcional)
+GRAYLOG_URL=http://localhost:12201/gelf
+
 # Todos os modelos utilizados pelo projeto sao configurados abaixo
 
 # Caminho para o arquivo de log lido pelo coletor

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Este projeto coleta logs gerados pelo `rsyslog`, armazena em um banco PostgreSQL
    ```bash
    pip install -r requirements.txt
    ```
-3. Copie `.env.example` para `.env` e preencha as credenciais do banco e o endereço do Elasticsearch.
+3. Copie `.env.example` para `.env` e preencha as credenciais do banco, o endereço do Elasticsearch e o `GRAYLOG_URL` caso queira encaminhar os eventos para o Graylog.
 4. Crie o banco de dados e aplique o script `schema.sql`.
 5. Ajuste o `rsyslog` conforme [docs/rsyslog_optimization.md](docs/rsyslog_optimization.md) para registrar os eventos em `rsyslog.log` (ou caminho definido em `LOG_FILE`).
 
@@ -124,6 +124,10 @@ graylog:
 
 Com esse ajuste o arquivo é criado corretamente e o serviço passa a iniciar
 normalmente.
+
+Com o Graylog em execução, defina a variável `GRAYLOG_URL` no `.env` (por
+padrão `http://localhost:12201/gelf`) para que o coletor envie cada registro
+processado diretamente para o Graylog utilizando o formato GELF.
 
 
 ### Configurando inputs

--- a/log_analyzer/config.py
+++ b/log_analyzer/config.py
@@ -24,6 +24,9 @@ DB_PASSWORD = _require_env("PG_PASS")
 # URL de conexao com o Elasticsearch
 ES_URL = os.getenv("ES_URL", "http://localhost:9200")
 
+# URL do input GELF do Graylog
+GRAYLOG_URL = os.getenv("GRAYLOG_URL")
+
 LOG_FILE = Path(os.getenv("LOG_FILE", "rsyslog.log"))
 
 SEVERITY_MODEL = _require_env("SEVERITY_MODEL")

--- a/log_analyzer/graylog_client.py
+++ b/log_analyzer/graylog_client.py
@@ -1,0 +1,20 @@
+import json
+from typing import Any, Mapping
+
+import requests
+
+from log_analyzer.config import GRAYLOG_URL
+
+
+def send_gelf(payload: Mapping[str, Any]) -> None:
+    """Send a GELF payload to Graylog if GRAYLOG_URL is defined."""
+    if not GRAYLOG_URL:
+        return
+
+    try:
+        headers = {"Content-Type": "application/json"}
+        # requests will raise for non-2xx responses
+        requests.post(GRAYLOG_URL, data=json.dumps(payload), headers=headers, timeout=5).raise_for_status()
+    except Exception:
+        # Ignore failures to avoid breaking the collector
+        pass

--- a/log_analyzer/log_db.py
+++ b/log_analyzer/log_db.py
@@ -1,5 +1,6 @@
 import psycopg2
 from typing import Iterable, Tuple, Any
+from datetime import datetime
 
 from .config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
 
@@ -156,6 +157,25 @@ class LogDB:
                     "semantic_outlier": semantic_outlier,
                 },
             )
+        except Exception:
+            pass
+
+        try:
+            from .graylog_client import send_gelf
+
+            gelf = {
+                "version": "1.1",
+                "host": host,
+                "short_message": message,
+                "timestamp": datetime.fromisoformat(timestamp).timestamp(),
+                "_program": program,
+                "_category": category,
+                "_severity": severity,
+                "_anomaly_score": anomaly_score,
+                "_malicious": malicious,
+                "_semantic_outlier": semantic_outlier,
+            }
+            send_gelf(gelf)
         except Exception:
             pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ bitsandbytes
 accelerate
 protobuf
 elasticsearch
+requests


### PR DESCRIPTION
## Summary
- add optional `GRAYLOG_URL` in config and `.env.example`
- install requests library
- implement `graylog_client.send_gelf`
- send GELF logs from `log_db.insert_log`
- document Graylog URL in README

## Testing
- `python -m py_compile log_analyzer/graylog_client.py log_analyzer/log_db.py log_analyzer/config.py`

------
https://chatgpt.com/codex/tasks/task_e_6866a379eb0c832aab30b0a87e3561a3