### PR TITLE
Enable automatic start of collector and network tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["python", "menu.py"]
+CMD ["python", "start_services.py"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Todas as variáveis podem ser exportadas no ambiente ou definidas diretamente no
    python -m log_analyzer.web_panel
    ```
    Ela ficará disponível em `http://localhost:5000` com filtros de severidade, busca textual e contadores gerais. Novos registros aparecem em tempo real com um indicativo de atividade. Na aba "Tráfego de rede" são exibidos os eventos classificados pelo NIDS.
-4. Você pode utilizar `python menu.py` para iniciar e parar os serviços a partir de um menu interativo, além de alternar entre **CPU** e **GPU** ou selecionar a interface de rede.
+4. O contêiner inicia automaticamente o coletor, o sniffer e o NIDS utilizando a rede do host. Caso prefira um controle manual, execute `python menu.py` para iniciar e parar os serviços, alternar entre **CPU** e **GPU** ou selecionar a interface de rede.
 
 ## Personalizando Modelos
 Os nomes dos modelos de IA podem ser alterados facilmente pelas variáveis do `.env`. Utilize `SEVERITY_MODEL` e `ANOMALY_MODEL` para classificadores de logs, `SEMANTIC_MODEL` para detecção semântica, `NIDS_MODEL` para tráfego de rede e `HUGGINGFACE_MODEL` para análises pontuais via LLM. Ajuste `ANOMALY_THRESHOLD` para calibrar a pontuação considerada suspeita.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,7 @@ services:
         condition: service_started
     volumes:
       - .:/app
-    networks:
-      - graylog
+    network_mode: host
 
 networks:
   graylog:

--- a/start_services.py
+++ b/start_services.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Start log collector, network sniffer and NIDS on container startup."""
+
+import os
+import signal
+import subprocess
+import sys
+
+processes = []
+
+MODULES = [
+    "log_analyzer.net_sniffer",
+    "log_analyzer.collector",
+    "log_analyzer.network_nids",
+]
+
+
+def start() -> None:
+    """Start all required modules as subprocesses."""
+    interface = os.getenv("NET_INTERFACE")
+    if not interface:
+        print("Variavel NET_INTERFACE nao definida.")
+        sys.exit(1)
+    for module in MODULES:
+        proc = subprocess.Popen([sys.executable, "-m", module])
+        processes.append(proc)
+
+
+def stop(signum, frame) -> None:  # type: ignore[return-type]
+    """Terminate child processes gracefully on container stop."""
+    for proc in processes:
+        if proc.poll() is None:
+            proc.terminate()
+    for proc in processes:
+        if proc.poll() is None:
+            proc.wait()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    start()
+    for proc in processes:
+        proc.wait()


### PR DESCRIPTION
## Summary
- launch collector, sniffer and NIDS automatically when the container starts
- use host networking so tcpdump captures host traffic
- adjust documentation explaining the new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866d9adfe64832a82c8e55217b8442a