### PR TITLE
Show network info in every tab

### DIFF
--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -30,11 +30,11 @@
     </li>
   </ul>
   <div id="toolbar" class="mt-auto small pt-3">
-    <div class="mb-1"><span id="severity-info"></span></div>
-    <div class="mb-1"><span id="nids-info"></span></div>
-    <div class="mb-1"><span id="attack-info"></span></div>
-    <div class="mb-1 text-danger"><span id="alert-info"></span></div>
-    <div class="mb-2"><span id="iface-info"></span></div>
+    <div class="mb-1"><strong>Logs:</strong> <span id="severity-info"></span></div>
+    <div class="mb-1"><strong>Tráfego:</strong> <span id="nids-info"></span></div>
+    <div class="mb-1"><strong>Ataques:</strong> <span id="attack-info"></span></div>
+    <div class="mb-1 text-danger"><strong>Alerta:</strong> <span id="alert-info"></span></div>
+    <div class="mb-2"><strong>Interfaces:</strong> <span id="iface-info"></span></div>
     <button id="theme-toggle" class="btn btn-sm btn-outline-secondary w-100" type="button">
       <i id="theme-icon" class="bi"></i>
     </button>
@@ -57,21 +57,15 @@ async function fetchStats() {
   const nids = document.getElementById('nids-info');
   const attacks = document.getElementById('attack-info');
   const iface = document.getElementById('iface-info');
-  sev.innerHTML = '';
-  nids.innerHTML = '';
-  if (currentMenu !== 'network') {
-    sev.innerHTML = Object.entries(data.severity).map(
-      ([k,v]) => `<span class="${SEVERITY_COLORS[k] || ''} me-2">${k}: ${v}</span>`
-    ).join(' ');
-  }
+  sev.innerHTML = Object.entries(data.severity).map(
+    ([k,v]) => `<span class="${SEVERITY_COLORS[k] || ''} me-2">${k}: ${v}</span>`
+  ).join(' ');
   attacks.textContent = Object.entries(data.attacks).map(
     ([k,v]) => `${k}: ${v}`
   ).join(' ');
-  if (currentMenu === 'network') {
-    nids.innerHTML = Object.entries(data.network_labels || {}).map(
-      ([k,v]) => `<span class="${LABEL_COLORS[k.toLowerCase()] || ''} me-2">${k}: ${v}</span>`
-    ).join(' ');
-  }
+  nids.innerHTML = Object.entries(data.network_labels || {}).map(
+    ([k,v]) => `<span class="${LABEL_COLORS[k.toLowerCase()] || ''} me-2">${k}: ${v}</span>`
+  ).join(' ');
   iface.textContent = `Ativas: ${data.interfaces.active.join(', ')} | Atividade: ${data.interfaces.activity.join(', ')}`;
 }
 


### PR DESCRIPTION
## Summary
- show severity, attack and network stats in the sidebar on all pages
- label sidebar info with clearer headings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686724820ee8832a84c761676b72f02d