### PR TITLE
Split pipeline rule

### DIFF
--- a/Graylog/pipeline_rules.conf
+++ b/Graylog/pipeline_rules.conf
@@ -1,13 +1,22 @@
-rule "parse_full_message"
+rule "parse_service_logs"
 when
   has_field("message")
 then
   let msg = to_string($message.message);
   let svc = regex("service=(\\w+)", msg);
+  set_fields(fields: {
+    source_service: svc.matches ? svc.group[1] : null
+  });
+end
+
+rule "parse_network_packet"
+when
+  has_field("message")
+then
+  let msg = to_string($message.message);
   let ip  = regex("(\d+\.\d+\.\d+\.\d+)\.(\d+) > (\d+\.\d+\.\d+\.\d+)\.(\d+)", msg);
   let proto = regex("proto=(\w+)", msg);
   set_fields(fields: {
-    source_service: svc.matches ? svc.group[1] : null,
     src_ip: ip.matches ? ip.group[1] : null,
     src_port: ip.matches ? ip.group[2] : null,
     dst_ip: ip.matches ? ip.group[3] : null,


### PR DESCRIPTION
## Summary
- split generic pipeline rule into two
- document new rules for Graylog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686738e8c2a8832ab0b50942bd89cc17