### PR TITLE
Fix static IP for OpenSearch and Graylog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,10 @@ GRAYLOG_ROOT_PASSWORD_SHA2=superSenhaComplexa123!
 OPENSEARCH_INITIAL_ADMIN_PASSWORD=superSenhaComplexa123!
 
 # URL de conexao para o Elasticsearch
-ES_URL=http://localhost:9200
+ES_URL=http://172.30.0.2:9200
 
 # Endpoint GELF para envio de logs e eventos de rede ao Graylog (opcional)
-GRAYLOG_URL=http://localhost:12201/gelf
+GRAYLOG_URL=http://172.30.0.3:12201/gelf
 
 # Todos os modelos utilizados pelo projeto sao configurados abaixo
 

--- a/Graylog/graylog.conf
+++ b/Graylog/graylog.conf
@@ -1,6 +1,6 @@
 is_master = true
 http_bind_address = 0.0.0.0:9000
-elasticsearch_hosts = http://elasticsearch:9200
+elasticsearch_hosts = http://172.30.0.2:9200
 mongodb_uri = mongodb://mongo:27017/graylog
 root_timezone = UTC
 allow_highlighting = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,12 @@ services:
     volumes:
       - opensearch_data:/usr/share/opensearch/data
     networks:
-      - graylog
+      graylog:
+        ipv4_address: 172.30.0.2
 
   graylog:
     # Versão Community do Graylog
-    image: graylog/graylog:6.3.0 
+    image: graylog/graylog:6.3.0
     container_name: graylog
     restart: on-failure
     depends_on:
@@ -54,7 +55,7 @@ services:
       GRAYLOG_HTTP_BIND_ADDRESS: "0.0.0.0:9000"
       GRAYLOG_HTTP_EXTERNAL_URI: "http://localhost:9000/"
       GRAYLOG_MONGODB_URI: "mongodb://mongodb:27017/graylog"
-      GRAYLOG_ELASTICSEARCH_HOSTS: "http://opensearch:9200"
+      GRAYLOG_ELASTICSEARCH_HOSTS: "http://172.30.0.2:9200"
       GRAYLOG_PASSWORD_SECRET: "muitoseguraepepper1234567890"
       # Usuario e senha definidos no .env
       GRAYLOG_ROOT_USERNAME: "${GRAYLOG_ROOT_USERNAME}"
@@ -71,7 +72,8 @@ services:
     volumes:
       - graylog_journal:/usr/share/graylog/data
     networks:
-      - graylog
+      graylog:
+        ipv4_address: 172.30.0.3
 
 #  analises_logs:
 #    build: .
@@ -91,6 +93,9 @@ services:
 networks:
   graylog:
     driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24
 
 volumes:
   mongodb_data:


### PR DESCRIPTION
## Summary
- set fixed IPs for OpenSearch and Graylog containers
- update compose network to use defined subnet
- reference the new container IPs in `.env.example`
- point Graylog configuration to the new OpenSearch IP

## Testing
- `python -m compileall -q log_analyzer`
- `python -m py_compile start_services.py menu.py log_analyzer/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6867d7018430832a9d995ee0a7056c13