### PR TITLE
Add static IP for MongoDB container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       - mongodb_data:/data/db
       - mongodb_config:/data/configdb
     networks:
-      - analise_logs
+      analise_logs:
+        ipv4_address: 172.30.0.4
 
   opensearch:
     image: opensearchproject/opensearch:2.15.0


### PR DESCRIPTION
## Summary
- assign IP `172.30.0.4` to the MongoDB service in `docker-compose.yml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867df65e17c832a82f30bdeb9c64ea1