### PR TITLE
Add Graylog extractor examples

### DIFF
--- a/Graylog/extractors.json
+++ b/Graylog/extractors.json
@@ -1,0 +1,47 @@
+{
+  "extractors": [
+    {
+      "title": "ssh_login_fail",
+      "type": "regex",
+      "cursor_strategy": "copy",
+      "source_field": "message",
+      "target_field": "message",
+      "extractor_config": {
+        "regex_value": "Failed password for (?:invalid user )?(?<username>\\w+) from (?<src_ip>\\d+\\.\\d+\\.\\d+\\.\\d+) port (?<port>\\d+)"
+      },
+      "converters": [],
+      "order": 0,
+      "condition_type": "regex",
+      "condition_value": "Failed password"
+    },
+    {
+      "title": "network_packet",
+      "type": "grok",
+      "cursor_strategy": "copy",
+      "source_field": "message",
+      "target_field": "message",
+      "extractor_config": {
+        "grok_pattern": "IP %{IP:src_ip}.%{INT:src_port} > %{IP:dst_ip}.%{INT:dst_port}: %{GREEDYDATA:packet_info}"
+      },
+      "converters": [],
+      "order": 1,
+      "condition_type": "regex",
+      "condition_value": "^IP"
+    },
+    {
+      "title": "service_field",
+      "type": "regex",
+      "cursor_strategy": "copy",
+      "source_field": "message",
+      "target_field": "source_service",
+      "extractor_config": {
+        "regex_value": "service=(?<source_service>\\w+)"
+      },
+      "converters": [],
+      "order": 2,
+      "condition_type": "regex",
+      "condition_value": "service="
+    }
+  ],
+  "version": "1"
+}

--- a/docs/graylog_extractors.md
+++ b/docs/graylog_extractors.md
@@ -47,3 +47,7 @@ Para separar endereços e portas:
 ## 4. Verificando os resultados
 
 Retorne à tela **Search** e envie alguns logs para o Graylog. Os campos extraídos ficarão disponíveis para filtros, widgets de dashboard e regras de pipeline. Caso deseje realizar ajustes ou adicionar novos padrões, repita os passos acima em **Manage extractors**.
+
+## 5. Importação via JSON
+
+Se preferir importar extratores já prontos, utilize o menu **Actions > Import Extractors** dentro de **Manage extractors** e cole o conteúdo do arquivo `Graylog/extractors.json` deste repositório. Os campos serão criados automaticamente.


### PR DESCRIPTION
## Summary
- add extractor JSON for common log patterns
- document how to import the file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867f070dc54832a83ebf6463616a68b