### PR TITLE
Refine Graylog extractor definitions

### DIFF
--- a/Graylog/extractors.json
+++ b/Graylog/extractors.json
@@ -7,7 +7,8 @@
       "source_field": "message",
       "target_field": "message",
       "extractor_config": {
-        "regex_value": "Failed password for (?:invalid user )?(?<username>\\w+) from (?<src_ip>\\d+\\.\\d+\\.\\d+\\.\\d+) port (?<port>\\d+)"
+        "regex_value": "Failed password for (?:invalid user )?(?<username>\\w+) from (?<src_ip>\\d+\\.\\d+\\.\\d+\\.\\d+) port (?<port>\\d+)",
+        "regex_flags": "MULTILINE"
       },
       "converters": [],
       "order": 0,
@@ -21,7 +22,8 @@
       "source_field": "message",
       "target_field": "message",
       "extractor_config": {
-        "grok_pattern": "IP %{IP:src_ip}.%{INT:src_port} > %{IP:dst_ip}.%{INT:dst_port}: %{GREEDYDATA:packet_info}"
+        "grok_pattern": "IP %{IP:src_ip}.%{INT:src_port} > %{IP:dst_ip}.%{INT:dst_port}: %{GREEDYDATA:packet_info}",
+        "named_captures_only": true
       },
       "converters": [],
       "order": 1,
@@ -35,7 +37,8 @@
       "source_field": "message",
       "target_field": "source_service",
       "extractor_config": {
-        "regex_value": "service=(?<source_service>\\w+)"
+        "regex_value": "service=(?<source_service>\\w+)",
+        "regex_flags": "MULTILINE"
       },
       "converters": [],
       "order": 2,

--- a/docs/graylog_extractors.md
+++ b/docs/graylog_extractors.md
@@ -24,6 +24,8 @@ Para extrair o nome do usuário, o IP de origem e a porta:
    ```
    Failed password for (?:invalid user )?(?<username>\w+) from (?<src_ip>\d+\.\d+\.\d+\.\d+) port (?<port>\d+)
    ```
+   Utilize a opção **Regex flags** com o valor `MULTILINE` para abranger mensagens
+   quebradas em mais de uma linha.
 4. Marque **Store as field** e salve os campos `username`, `src_ip` e `port`.
 5. Clique em **Try** para testar o extrator e, se os valores estiverem corretos, confirme em **Save**.
 
@@ -38,7 +40,8 @@ IP 192.168.1.10.5678 > 10.0.0.5.80: Flags [S], seq 12345, length 0
 Para separar endereços e portas:
 
 1. No mesmo menu de extratores, clique em **Add extractor** e escolha **Grok pattern**.
-2. Defina o campo **message** como fonte e adote o seguinte padrão:
+2. Defina o campo **message** como fonte e adote o seguinte padrão
+   marcando **Named captures only** para evitar campos numerados:
    ```
    IP %{IP:src_ip}.%{INT:src_port} > %{IP:dst_ip}.%{INT:dst_port}: %{GREEDYDATA:packet_info}
    ```


### PR DESCRIPTION
## Summary
- adjust extractor JSON to include regex flags and named captures
- document regex flags and named captures options in extractor guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867f23b1a3c832a82253fe732b7c57a