### PR TITLE
Improve sidebar layout

### DIFF
--- a/log_analyzer/static/styles.css
+++ b/log_analyzer/static/styles.css
@@ -30,6 +30,26 @@ body {
   padding: 10px 15px;
 }
 
+.sidebar-info .info-section {
+  margin-bottom: 8px;
+}
+
+.sidebar-info .info-section-title {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.sidebar-info .alert-section {
+  color: #dd4b39;
+}
+
+.sidebar-info .label {
+  display: inline-block;
+  margin-right: 4px;
+  margin-bottom: 2px;
+}
+
 body.dark-mode {
   background-color: #1e282c;
   color: #c2c7d0;

--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -44,12 +44,25 @@
         </li>
         <li class="header">INFORMAÇÕES</li>
         <li class="sidebar-info">
-          <div class="p-2">
-            <strong>Severidade:</strong> <span id="severity-info"></span><br>
-            <strong>Ataques:</strong> <span id="attack-info"></span><br>
-            <span class="text-red"><strong>Alerta:</strong> <span id="alert-info"></span></span><br>
-            <strong>Tráfego:</strong> <span id="nids-info"></span><br>
-            <strong>Placas:</strong> <span id="iface-info"></span>
+          <div class="info-section">
+            <span class="info-section-title">Severidade</span>
+            <div id="severity-info"></div>
+          </div>
+          <div class="info-section">
+            <span class="info-section-title">Ataques</span>
+            <div id="attack-info"></div>
+          </div>
+          <div class="info-section alert-section">
+            <span class="info-section-title">Alerta</span>
+            <div id="alert-info"></div>
+          </div>
+          <div class="info-section">
+            <span class="info-section-title">Tráfego</span>
+            <div id="nids-info"></div>
+          </div>
+          <div class="info-section">
+            <span class="info-section-title">Placas</span>
+            <div id="iface-info"></div>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- reorganize sidebar info blocks
- style sidebar sections with clearer labels

## Testing
- `python -m py_compile log_analyzer/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6873f5b89f84832a848b8038ea657cdd