### PR TITLE
Improve web dashboard with theme-aware toolbar and new dashboard page

### DIFF
--- a/log_analyzer/static/styles.css
+++ b/log_analyzer/static/styles.css
@@ -2,6 +2,20 @@
 body {
   font-family: Arial, sans-serif;
 }
+.light-navbar {
+  background-color: #f9fafc;
+  color: #333;
+}
+.light-navbar a {
+  color: #333;
+}
+.dark-navbar {
+  background-color: #222d32;
+  color: #c2c7d0;
+}
+.dark-navbar a {
+  color: #c2c7d0;
+}
 .list-group-item {
   border-radius: 0.25rem;
   margin-bottom: 0.5rem;

--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -18,7 +18,7 @@
       <span class="logo-mini"><b>L</b>A</span>
       <span class="logo-lg"><b>Log</b>Dashboard</span>
     </a>
-    <nav class="navbar navbar-static-top">
+    <nav id="top-nav" class="navbar navbar-static-top light-navbar">
       <a href="#" class="sidebar-toggle" data-toggle="push-menu" role="button">
         <span class="sr-only">Toggle navigation</span>
       </a>
@@ -33,6 +33,9 @@
     <section class="sidebar">
       <ul class="sidebar-menu" data-widget="tree">
         <li class="header">MENU</li>
+        <li class="{% if menu=='dashboard' %}active{% endif %}">
+          <a href="{{ url_for('dashboard_page') }}"><i class="fa fa-dashboard"></i> <span>Dashboard</span></a>
+        </li>
         <li class="{% if menu=='logs' %}active{% endif %}">
           <a href="{{ url_for('logs_page') }}"><i class="fa fa-file-text-o"></i> <span>Logs</span><small id="badge-logs" class="label pull-right bg-red hidden">+1</small></a>
         </li>
@@ -123,6 +126,13 @@ function applyTheme(theme){
     body.classList.add('skin-black','dark-mode');
   }else{
     body.classList.add('skin-blue');
+  }
+  const nav=document.getElementById('top-nav');
+  nav.classList.remove('dark-navbar','light-navbar');
+  if(theme==='dark'){
+    nav.classList.add('dark-navbar');
+  }else{
+    nav.classList.add('light-navbar');
   }
   document.getElementById('theme-icon').className=theme==='dark'?'fa fa-moon-o':'fa fa-sun-o';
 }

--- a/log_analyzer/templates/dashboard.html
+++ b/log_analyzer/templates/dashboard.html
@@ -1,0 +1,100 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row" id="count-cards">
+  <div class="col-lg-4 col-xs-6">
+    <div class="small-box bg-aqua">
+      <div class="inner">
+        <h3 id="count-logs">0</h3>
+        <p>Logs</p>
+      </div>
+      <div class="icon"><i class="fa fa-file-text-o"></i></div>
+    </div>
+  </div>
+  <div class="col-lg-4 col-xs-6">
+    <div class="small-box bg-green">
+      <div class="inner">
+        <h3 id="count-analyzed">0</h3>
+        <p>Analisados</p>
+      </div>
+      <div class="icon"><i class="fa fa-check"></i></div>
+    </div>
+  </div>
+  <div class="col-lg-4 col-xs-6">
+    <div class="small-box bg-yellow">
+      <div class="inner">
+        <h3 id="count-network">0</h3>
+        <p>Eventos de Rede</p>
+      </div>
+      <div class="icon"><i class="fa fa-exchange"></i></div>
+    </div>
+  </div>
+</div>
+<section class="content" id="severity-section">
+  <div class="box box-primary">
+    <div class="box-header with-border">
+      <h3 class="box-title">Severidade</h3>
+    </div>
+    <div class="box-body">
+      <div class="progress-group">
+        INFO
+        <span class="pull-right"><b id="sev-info-count">0</b></span>
+        <div class="progress progress-sm">
+          <div id="sev-info-bar" class="progress-bar progress-bar-info" style="width:0%"></div>
+        </div>
+      </div>
+      <div class="progress-group">
+        WARNING
+        <span class="pull-right"><b id="sev-warn-count">0</b></span>
+        <div class="progress progress-sm">
+          <div id="sev-warn-bar" class="progress-bar progress-bar-warning" style="width:0%"></div>
+        </div>
+      </div>
+      <div class="progress-group">
+        ERROR
+        <span class="pull-right"><b id="sev-error-count">0</b></span>
+        <div class="progress progress-sm">
+          <div id="sev-error-bar" class="progress-bar progress-bar-danger" style="width:0%"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="content" id="network-section">
+  <div class="box box-primary">
+    <div class="box-header with-border">
+      <h3 class="box-title">Etiquetas de Rede</h3>
+    </div>
+    <div class="box-body">
+      <canvas id="network-chart" height="100"></canvas>
+    </div>
+  </div>
+</section>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+async function loadDashboard(){
+  const respCounts=await fetch('/api/counts');
+  if(respCounts.ok){
+    const c=await respCounts.json();
+    document.getElementById('count-logs').textContent=c.logs;
+    document.getElementById('count-analyzed').textContent=c.analyzed;
+    document.getElementById('count-network').textContent=c.network;
+  }
+  const resp=await fetch('/api/stats');
+  if(!resp.ok) return;
+  const data=await resp.json();
+  const total=(data.severity.INFO||0)+(data.severity.WARNING||0)+(data.severity.ERROR||0);
+  function upd(id,count){
+    document.getElementById(id+'-count').textContent=count;
+    document.getElementById(id+'-bar').style.width=total?((count/total)*100)+'%':'0%';
+  }
+  upd('sev-info',data.severity.INFO||0);
+  upd('sev-warn',data.severity.WARNING||0);
+  upd('sev-error',data.severity.ERROR||0);
+  const labels=Object.keys(data.network_labels||{});
+  const values=Object.values(data.network_labels||{});
+  const ctx=document.getElementById('network-chart');
+  new Chart(ctx,{type:'doughnut',data:{labels:labels,datasets:[{data:values,backgroundColor:['#d2d6de','#f39c12','#dd4b39','#00c0ef','#3c8dbc']}]},options:{maintainAspectRatio:false}});
+}
+loadDashboard();
+</script>
+{% endblock %}

--- a/log_analyzer/web_panel.py
+++ b/log_analyzer/web_panel.py
@@ -63,7 +63,12 @@ def get_network_info() -> tuple[list[str], list[str]]:
 
 @app.route("/")
 def index():
-    return redirect(url_for("logs_page"))
+    return redirect(url_for("dashboard_page"))
+
+
+@app.route("/dashboard")
+def dashboard_page():
+    return render_template("dashboard.html", menu="dashboard")
 
 
 @app.route("/logs")


### PR DESCRIPTION
## Summary
- style toolbar for light & dark themes
- add dashboard page with cards, progress bars and charts
- link new dashboard in the sidebar
- route root URL to dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873f7dabb74832aad533bc012eb20da