### PR TITLE
Fix severity colors undefined

### DIFF
--- a/log_analyzer/templates/base.html
+++ b/log_analyzer/templates/base.html
@@ -81,7 +81,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/admin-lte@2.4.18/dist/js/adminlte.min.js"></script>
 <script>
-const SEVERITY_COLORS = {{ severity_colors | tojson }};
+const SEVERITY_COLORS = {{ severity_colors | default({}, true) | tojson }};
 const LABEL_COLORS = {{ label_colors | default({}, true) | tojson }};
 const currentMenu = '{{ menu }}';
 async function fetchStats(){


### PR DESCRIPTION
## Summary
- prevent exception when `severity_colors` isn't passed to the template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873f99ccbc4832a9fc4badd915e83bf